### PR TITLE
sct sbbr tests: fix memory map allocation

### DIFF
--- a/common/sct-tests/sbbr-tests/SbbrBootServices/BlackBoxTest/SbbrBootServicesBBTestFunction.c
+++ b/common/sct-tests/sbbr-tests/SbbrBootServices/BlackBoxTest/SbbrBootServicesBBTestFunction.c
@@ -166,6 +166,15 @@ BBTestMemoryMapTest (
                 );
     return EFI_SUCCESS;
   }
+
+  //
+  // The memory size needs to be increased, because there is a call to
+  // SctAllocatePool() before the second GetMemoryMap(), the action of allocate
+  // pool might increase the MemoryMapSize. Increasing by 1KB should be enough
+  // for anyone.
+  //
+  MemoryMapSize += 1024;
+
   MemoryMap = SctAllocatePool(MemoryMapSize);
   if (MemoryMap == 0) {
     return EFI_OUT_OF_RESOURCES;

--- a/common/sct-tests/sbbr-tests/SbbrSmbios/BlackBoxTest/SbbrSmbiosBBTestMain.c
+++ b/common/sct-tests/sbbr-tests/SbbrSmbios/BlackBoxTest/SbbrSmbiosBBTestMain.c
@@ -160,6 +160,15 @@ SbbrAllocAndGetMemoryMap (
     if (Status != EFI_BUFFER_TOO_SMALL){
       return EFI_NOT_FOUND;
     }
+
+    //
+    // The memory size needs to be increased, because there is a call to
+    // SctAllocatePool() before the second GetMemoryMap(), the action of allocate
+    // pool might increase the MemoryMapSize. Increasing by 1KB should be enough
+    // for anyone.
+    //
+    *MemoryMapSize += 1024;
+
     *MemoryMap = SctAllocatePool(*MemoryMapSize);
     if (*MemoryMap == NULL) {
       return EFI_OUT_OF_RESOURCES;


### PR DESCRIPTION
Hi,

Here is a fix to the allocation in BBTestMemoryMapTest() using the same method as the SCT, verified with U-Boot on qemu.
I did not run the SMBIOS test; let me know if you prefer that I drop the fix for this one instead.

Best regards,
Vincent.
