### PR TITLE
sbbr-test: define ACS_VERSION for RELEASE

### DIFF
--- a/common/sct-tests/sbbr-tests/BBR_SCT.dsc
+++ b/common/sct-tests/sbbr-tests/BBR_SCT.dsc
@@ -100,7 +100,7 @@
   RVCT:*_*_AARCH64_DLINK_FLAGS = --muldefweak
 
   DEBUG_*_*_CC_FLAGS  = -DEFI_DEBUG -DACS_VERSION=\"v1.0\"
-  RELEASE_*_*_CC_FLAGS  = -DMDEPKG_NDEBUG
+  RELEASE_*_*_CC_FLAGS  = -DMDEPKG_NDEBUG -DACS_VERSION=\"v1.0\"
 
 [Libraries]
   SctPkg/Library/SctLib/SctLib.inf


### PR DESCRIPTION
Building with `UEFI_BUILD_MODE=RELEASE` in [build-sct.sh](https://github.com/ARM-software/bbr-acs/blob/main/common/scripts/build-sct.sh) raised the following error:
```
/home/user/workspace/arm-systemready/SR/scripts/edk2-test/uefi-sct/SctPkg/TestInfrastructure/SCT/Drivers/StandardTest/StandardTest.c: In function ‘StslBeginLogging’:
/home/user/workspace/arm-systemready/SR/scripts/edk2-test/uefi-sct/SctPkg/TestInfrastructure/SCT/Drivers/StandardTest/StandardTest.c:1092:75: error: expected ‘)’ before ‘ACS_VERSION’
     SctSPrint (Buffer, EFI_MAX_PRINT_BUFFER, L"Arm ACS Version: %s\n", L""ACS_VERSION);
                                                                           ^~~~~~~~~~~
```

edk2-test-bbr.patch adds a print using the macro when applied to uefi-sct, so the macro has to be defined in both cases.