### PR TITLE
sct-test: change build_bbr.sh to support 32bit arm targets

### DIFF
--- a/common/sct-tests/sbbr-tests/build_bbr.sh
+++ b/common/sct-tests/sbbr-tests/build_bbr.sh
@@ -72,6 +72,12 @@ function set_cross_compile
 	    else
 	        TEMP_CROSS_COMPILE=aarch64-linux-gnu-
 	    fi
+	elif [ "$SCT_TARGET_ARCH" == "ARM" ]; then
+	    if [ X"$CROSS_COMPILE_32" != X"" ]; then
+	        TEMP_CROSS_COMPILE="$CROSS_COMPILE_32"
+	    else
+	        TEMP_CROSS_COMPILE=arm-linux-gnueabihf-
+	    fi
 	else
 	    echo "Unsupported target architecture '$SCT_TARGET_ARCH'!" >&2
 	fi

--- a/common/sct-tests/sbbr-tests/build_bbr.sh
+++ b/common/sct-tests/sbbr-tests/build_bbr.sh
@@ -43,6 +43,9 @@
 # Copyright (c) 2011, 2015-2020 ARM Ltd. All rights reserved.<BR>
 #
 
+# Prevent confusuion with environment ARCH string identifiers
+unset ARCH
+
 SctpackageDependencyList=(SctPkg BaseTools)
 
 function get_build_arch


### PR DESCRIPTION
2 patches to make build_bbr.h able to request building BBR SCT test image for 32bit arm architecture.
This series is not sufficient to build such an image. The BBR SCT description file explicitly supports only AARCH64 targets. This is to be addressed in another P-R.