### PR TITLE
Adapt FWTS build for 32b arm

### DIFF
--- a/common/fwts_build_dep-arm/include/bsd/string.h
+++ b/common/fwts_build_dep-arm/include/bsd/string.h
@@ -1,0 +1,107 @@
+#ifndef LIBBSD_STRING_H
+#define LIBBSD_STRING_H
+
+#include <stdlib.h>
+
+/*	$OpenBSD: strlcpy.c,v 1.12 2015/01/15 03:54:12 millert Exp $	*/
+
+/*
+ * Copyright (c) 1998, 2015 Todd C. Miller <Todd.Miller@courtesan.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/*
+ * Copy string src to buffer dst of size dsize.  At most dsize-1
+ * chars will be copied.  Always NUL terminates (unless dsize == 0).
+ * Returns strlen(src); if retval >= dsize, truncation occurred.
+ */
+static inline size_t
+strlcpy(char *dst, const char *src, size_t dsize)
+{
+	const char *osrc = src;
+	size_t nleft = dsize;
+
+	/* Copy as many bytes as will fit. */
+	if (nleft != 0) {
+		while (--nleft != 0) {
+			if ((*dst++ = *src++) == '\0')
+				break;
+		}
+	}
+
+	/* Not enough room in dst, add NUL and traverse rest of src. */
+	if (nleft == 0) {
+		if (dsize != 0)
+			*dst = '\0';		/* NUL-terminate dst */
+		while (*src++)
+			;
+	}
+
+	return(src - osrc - 1);	/* count does not include NUL */
+}
+
+/*	$OpenBSD: strlcat.c,v 1.15 2015/03/02 21:41:08 millert Exp $	*/
+
+/*
+ * Copyright (c) 1998, 2015 Todd C. Miller <Todd.Miller@courtesan.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/*
+ * Appends src to string dst of size dsize (unlike strncat, dsize is the
+ * full size of dst, not space left).  At most dsize-1 characters
+ * will be copied.  Always NUL terminates (unless dsize <= strlen(dst)).
+ * Returns strlen(src) + MIN(dsize, strlen(initial dst)).
+ * If retval >= dsize, truncation occurred.
+ */
+static inline size_t
+strlcat(char *dst, const char *src, size_t dsize)
+{
+	const char *odst = dst;
+	const char *osrc = src;
+	size_t n = dsize;
+	size_t dlen;
+
+	/* Find the end of dst and adjust bytes left but don't go past end. */
+	while (n-- != 0 && *dst != '\0')
+		dst++;
+	dlen = dst - odst;
+	n = dsize - dlen;
+
+	if (n-- == 0)
+		return(dlen + strlen(src));
+	while (*src != '\0') {
+		if (n != 0) {
+			*dst++ = *src;
+			n--;
+		}
+		src++;
+	}
+	*dst = '\0';
+
+	return(dlen + (src - osrc));	/* count does not include NUL */
+}
+
+#endif

--- a/common/patches/0001-Build-only-what-we-use-to-test-EBBR-on-32b-arm.patch
+++ b/common/patches/0001-Build-only-what-we-use-to-test-EBBR-on-32b-arm.patch
@@ -1,0 +1,1587 @@
+From 1541f83e0215d574b1c2e3b872febb4b20280d63 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Vincent=20Stehl=C3=A9?= <vincent.stehle@arm.com>
+Date: Mon, 3 Oct 2022 15:35:30 +0200
+Subject: [PATCH] Build only what we use to test EBBR on 32b arm
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Simplify the build and reduce the dependencies to build for 32b arm, to
+test for EBBR.
+We remove all ACPI related and all the other features necessitating
+external dependencies. We do still depend on BSD strlcpy() and strlcat(),
+though.
+Also, we enable UEFI support for arm 32b where necessary and we fix the EFI
+status width to be in sync with the architecture instead of hardcoding to
+64b.
+
+Signed-off-by: Vincent Stehlé <vincent.stehle@arm.com>
+---
+ configure.ac                             |   2 -
+ src/Makefile.am                          | 177 +----------------------
+ src/lib/include/fwts.h                   |   6 +
+ src/lib/include/fwts_efi_runtime.h       |  22 +--
+ src/lib/include/fwts_uefi.h              |   6 +-
+ src/lib/src/Makefile.am                  |  35 +----
+ src/lib/src/fwts_fileio.c                |  38 -----
+ src/lib/src/fwts_framework.c             |   1 -
+ src/lib/src/fwts_uefi.c                  |  10 +-
+ src/uefi/securebootcert/securebootcert.c |   2 +-
+ src/uefi/uefirtauthvar/uefirtauthvar.c   |  34 ++---
+ src/uefi/uefirtmisc/uefirtmisc.c         |  16 +-
+ src/uefi/uefirttime/uefirttime.c         |  58 ++++----
+ src/uefi/uefirtvariable/uefirtvariable.c |  90 ++++++------
+ src/uefi/uefivarinfo/uefivarinfo.c       |  14 +-
+ 15 files changed, 143 insertions(+), 368 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index f40c3678..8e0d5b49 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -98,8 +98,6 @@
+ 	  AC_CONFIG_FILES([
+            Makefile
+            src/Makefile
+-	   src/libfwtsiasl/Makefile
+-	   src/libfwtsacpica/Makefile
+            src/lib/Makefile
+            src/lib/src/Makefile
+ 	   src/utilities/Makefile
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 9a26af86..71549d34 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -1,18 +1,10 @@
+-# Must build in this order:
+-#   1. acpica/source/compiler
+-#   2. lib
+-#   3. acpica
+-# ... because the libs in this bundled acpica/ depend on lib/ (libfwts.so),
+-# but libfwts.so depends on libraries produced by acpica/source/compiler.
+-SUBDIRS = libfwtsiasl lib libfwtsacpica
++SUBDIRS = lib
+ 
+ AM_CPPFLAGS = \
+ 	-I$(top_srcdir)/src/lib/include			\
+-	-I$(top_srcdir)/src/acpica/source/include	\
+-	-I$(top_srcdir)/src/acpica/source/compiler	\
+ 	-I$(top_srcdir)/efi_runtime			\
+ 	-I$(top_srcdir)/smccc_test			\
+-	-pthread `pkg-config --cflags glib-2.0 gio-2.0` \
++	-pthread                                        \
+ 	-Wall -Werror -Wextra				\
+ 	-Wno-address-of-packed-member			\
+ 	-Wfloat-equal -Wmissing-declarations		\
+@@ -23,173 +15,22 @@ AM_CPPFLAGS = \
+ 
+ bin_PROGRAMS = fwts
+ 
+-fwts_CPPFLAGS = $(AM_CPPFLAGS) -DACPI_DEBUG_OUTPUT
++fwts_CPPFLAGS = $(AM_CPPFLAGS)
+ 
+ if HAVE_LIBFDT
+ dt_tests = \
+ 	devicetree/dt_base/dt_base.c		\
+ 	devicetree/dt_sysinfo/dt_sysinfo.c
+-mem_tests = \
+-	opal/mem_info.c				\
+-	opal/reserv_mem.c
+-cpu_tests = \
+-	opal/cpu_info.c
+-power_mgmt_tests = \
+-	opal/power_mgmt_info.c
+-endif
+-
+-if HAVE_LIBFDT
+-if HAVE_LIBPCI
+-pci_tests = \
+-	opal/pci_info.c
+-endif
+ endif
+ 
+ #
+ #  fwts main + tests
+ #
+ fwts_SOURCES = main.c 				\
+-	acpi/ac_adapter/ac_adapter.c 		\
+-	acpi/acpidump/acpidump.c 		\
+-	acpi/acpiinfo/acpiinfo.c 		\
+-	acpi/acpitables/acpitables.c 		\
+-	sbbr/acpitables/acpitables.c 		\
+-	acpi/apicinstance/apicinstance.c 	\
+-	acpi/asf/asf.c				\
+-	acpi/aspt/aspt.c			\
+-	acpi/battery/battery.c 			\
+-	acpi/bert/bert.c			\
+-	acpi/bgrt/bgrt.c			\
+-	acpi/boot/boot.c			\
+-	acpi/brightness/brightness-helper.c	\
+-	acpi/brightness/brightness.c 		\
+-	acpi/brightness/autobrightness.c 	\
+-	acpi/checksum/checksum.c 		\
+-	acpi/cpep/cpep.c			\
+-	acpi/crsdump/crsdump.c			\
+-	acpi/crsdump/prsdump.c			\
+-	acpi/csrt/csrt.c			\
+-	acpi/cstates/cstates.c 			\
+-	acpi/dbgp/dbgp.c 			\
+-	acpi/dbg2/dbg2.c 			\
+-	acpi/devices/ac_adapter/ac.c		\
+-	acpi/devices/battery/battery.c		\
+-	acpi/devices/battery/smart_battery.c	\
+-	acpi/devices/ec/ec.c			\
+-	acpi/devices/buttons/power_button.c	\
+-	acpi/devices/buttons/sleep_button.c	\
+-	acpi/devices/lid/lid.c			\
+-	acpi/devices/nvdimm/nvdimm.c 			\
+-	acpi/devices/sensor/als.c		\
+-	acpi/devices/time/time.c		\
+-	acpi/devices/wpc/wpc.c			\
+-	acpi/dmar/dmar.c 			\
+-	acpi/dppt/dppt.c 			\
+-	acpi/drtm/drtm.c 			\
+-	acpi/dsddump/dsddump.c			\
+-	acpi/ecdt/ecdt.c			\
+-	acpi/einj/einj.c			\
+-	acpi/erst/erst.c			\
+-	acpi/facs/facs.c 			\
+-	acpi/fadt/fadt.c 			\
+-	sbbr/fadt/fadt.c 			\
+-	acpi/fan/fan.c 				\
+-	acpi/fpdt/fpdt.c 			\
+-	acpi/gpedump/gpedump.c			\
+-	acpi/gtdt/gtdt.c			\
+-	acpi/hest/hest.c			\
+-	acpi/hpet/hpet.c 			\
+-	acpi/hmat/hmat.c 			\
+-	acpi/iort/iort.c			\
+-	acpi/lid/lid.c 				\
+-	acpi/lpit/lpit.c 			\
+-	acpi/madt/madt.c			\
+-	acpi/mcfg/mcfg.c 			\
+-	acpi/mchi/mchi.c 			\
+-	acpi/mpst/mpst.c 			\
+-	acpi/msct/msct.c 			\
+-	acpi/msdm/msdm.c 			\
+-	acpi/method/method.c 			\
+-	acpi/nfit/nfit.c 			\
+-	acpi/osilinux/osilinux.c 		\
+-	acpi/pcc/pcc.c 				\
+-	acpi/pcct/pcct.c			\
+-	acpi/pdtt/pdtt.c			\
+-	acpi/powerbutton/powerbutton.c 		\
+-	acpi/plddump/plddump.c			\
+-	acpi/phat/phat.c 			\
+-	acpi/pmtt/pmtt.c 			\
+-	acpi/pptt/pptt.c 			\
+-	acpi/rasf/rasf.c			\
+-	acpi/rsdp/rsdp.c			\
+-	sbbr/rsdp/rsdp.c			\
+-	acpi/rsdt/rsdt.c			\
+-	acpi/s3/s3.c 				\
+-	acpi/s3power/s3power.c 			\
+-	acpi/s4/s4.c 				\
+-	acpi/sbst/sbst.c			\
+-	acpi/sdei/sdei.c			\
+-	acpi/sdev/sdev.c			\
+-	acpi/slic/slic.c 			\
+-	acpi/slit/slit.c 			\
+-	acpi/spcr/spcr.c 			\
+-	acpi/spmi/spmi.c 			\
+-	acpi/srat/srat.c 			\
+-	acpi/stao/stao.c			\
+-	acpi/syntaxcheck/syntaxcheck.c 		\
+-	acpi/tcpa/tcpa.c 			\
+-	acpi/tpm2/tpm2.c 			\
+-	acpi/uefi/uefi.c			\
+-	acpi/uniqueid/uniqueid.c		\
+-	acpi/waet/waet.c			\
+-	acpi/wakealarm/wakealarm.c 		\
+-	acpi/wdat/wdat.c			\
+-	acpi/wmi/wmi.c 				\
+-	acpi/wpbt/wpbt.c			\
+-	acpi/wsmt/wsmt.c			\
+-	acpi/xsdt/xsdt.c			\
+-	acpi/xenv/xenv.c			\
+-	apic/apicedge/apicedge.c 		\
+-	bios/bios_info/bios_info.c 		\
+-	bios/bios32/bios32.c 			\
+-	bios/ebda_region/ebda_region.c 		\
+-	bios/ebdadump/ebdadump.c 		\
+-	bios/hdaaudio/hdaaudio.c 		\
+-	bios/interrupt/interrupt.c		\
+-	bios/memmapdump/memmapdump.c 		\
+-	bios/mtrr/mtrr.c 			\
+-	bios/multiproc/mpcheck.c 		\
+-	bios/multiproc/mpdump.c 		\
+-	bios/pciirq/pciirq.c 			\
+-	bios/pnp/pnp.c 				\
+-	bios/romdump/romdump.c 			\
+-	bios/s0idle/s0idle.c 			\
+-	bios/smm/smm.c				\
+-	cmos/cmosdump/cmosdump.c 		\
+-	coreboot/clog/clog.c			\
+-	cpu/virt/virt.c 			\
+-	cpu/virt/virt_svm.c 			\
+-	cpu/virt/virt_vmx.c			\
+-	cpu/maxfreq/maxfreq.c 			\
+-	cpu/cpufreq/cpufreq.c 			\
+-	cpu/nx/nx.c 				\
+-	cpu/msr/msr.c 				\
+-	cpu/microcode/microcode.c 		\
+-	dmi/dmicheck/dmicheck.c 		\
+-	hotkey/hotkey/hotkey.c 			\
+-	ipmi/bmc/bmc_info.c			\
+ 	kernel/klog/klog.c 			\
+ 	kernel/olog/olog.c			\
+ 	kernel/oops/oops.c 			\
+ 	kernel/version/version.c 		\
+-	opal/mtd_info.c				\
+-	opal/prd_info.c				\
+-	pci/aspm/aspm.c 			\
+-	pci/crs/crs.c 				\
+-	pci/maxreadreq/maxreadreq.c 		\
+-	pci/smccc/smccc.c			\
+-	tpm/tpmevlog/tpmevlog.c			\
+-	tpm/tpmevlogdump/tpmevlogdump.c		\
+ 	uefi/csm/csm.c 				\
+ 	uefi/uefidump/uefidump.c 		\
+ 	uefi/uefirttime/uefirttime.c		\
+@@ -201,22 +42,14 @@ fwts_SOURCES = main.c 				\
+ 	uefi/uefirtauthvar/uefirtauthvar.c	\
+ 	uefi/esrtdump/esrtdump.c		\
+ 	uefi/esrt/esrt.c			\
+-	$(pci_tests)				\
+-	$(mem_tests)				\
+-	$(cpu_tests)				\
+-	$(power_mgmt_tests)			\
+ 	$(dt_tests)
+ 
+-fwts_LDFLAGS = -lm -lbsd `pkg-config --libs glib-2.0 gio-2.0`
++fwts_LDFLAGS = -lm
+ 
+ fwts_LDADD = \
+ 	-lfwts					\
+ 	-L$(top_builddir)/src			\
+-	-L$(top_builddir)/src/acpica		\
+-	-L$(top_builddir)/src/libfwtsiasl	\
+-	-L$(top_builddir)/src/libfwtsacpica	\
+-	-L$(top_builddir)/src/lib/src		\
+-	-lfwtsacpica
++	-L$(top_builddir)/src/lib/src
+ 
+ man_MANS = ../doc/fwts.1 ../doc/fwts-collect.1 ../doc/fwts-frontend-text.1
+ 
+diff --git a/src/lib/include/fwts.h b/src/lib/include/fwts.h
+index f34d4859..33486b30 100644
+--- a/src/lib/include/fwts.h
++++ b/src/lib/include/fwts.h
+@@ -127,6 +127,12 @@
+ #define FWTS_USE_DEVMEM 1
+ #endif
+ 
++#if defined(__arm__)
++#define FWTS_ARCH_ARM	1
++#define FWTS_HAS_UEFI	1
++#define FWTS_USE_DEVMEM 1
++#endif
++
+ /* verision 3-tuple into integer */
+ #define _VER_(major, minor, patchlevel)                 \
+ 	((major * 10000) + (minor * 100) + patchlevel)
+diff --git a/src/lib/include/fwts_efi_runtime.h b/src/lib/include/fwts_efi_runtime.h
+index 196d1735..15afd087 100644
+--- a/src/lib/include/fwts_efi_runtime.h
++++ b/src/lib/include/fwts_efi_runtime.h
+@@ -19,6 +19,8 @@
+ #ifndef _FWTS_EFI_RUNTIME_H_
+ #define _FWTS_EFI_RUNTIME_H_
+ 
++typedef unsigned long efi_status_t;
++
+ typedef enum {
+ 	EfiResetCold,
+ 	EfiResetWarm,
+@@ -66,7 +68,7 @@ struct efi_getvariable {
+ 	uint32_t	*Attributes;
+ 	uint64_t	*DataSize;
+ 	void		*Data;
+-	uint64_t	*status;
++	efi_status_t	*status;
+ } __attribute__ ((packed));
+ 
+ struct efi_setvariable {
+@@ -75,14 +77,14 @@ struct efi_setvariable {
+ 	uint32_t	Attributes;
+ 	uint64_t	DataSize;
+ 	void		*Data;
+-	uint64_t	*status;
++	efi_status_t	*status;
+ } __attribute__ ((packed));
+ 
+ struct efi_getnextvariablename {
+ 	uint64_t	*VariableNameSize;
+ 	uint16_t	*VariableName;
+ 	EFI_GUID	*VendorGuid;
+-	uint64_t	*status;
++	efi_status_t	*status;
+ } __attribute__ ((packed));
+ 
+ struct efi_queryvariableinfo {
+@@ -90,36 +92,36 @@ struct efi_queryvariableinfo {
+ 	uint64_t	*MaximumVariableStorageSize;
+ 	uint64_t	*RemainingVariableStorageSize;
+ 	uint64_t	*MaximumVariableSize;
+-	uint64_t	*status;
++	efi_status_t	*status;
+ } __attribute__ ((packed));
+ 
+ struct efi_gettime {
+ 	EFI_TIME		*Time;
+ 	EFI_TIME_CAPABILITIES	*Capabilities;
+-	uint64_t		*status;
++	efi_status_t		*status;
+ } __attribute__ ((packed));
+ 
+ struct efi_settime {
+ 	EFI_TIME		*Time;
+-	uint64_t		*status;
++	efi_status_t		*status;
+ } __attribute__ ((packed));
+ 
+ struct efi_getwakeuptime {
+ 	uint8_t		*Enabled;
+ 	uint8_t		*Pending;
+ 	EFI_TIME	*Time;
+-	uint64_t	*status;
++	efi_status_t	*status;
+ } __attribute__ ((packed));
+ 
+ struct efi_setwakeuptime {
+ 	uint8_t		Enabled;
+ 	EFI_TIME	*Time;
+-	uint64_t	*status;
++	efi_status_t	*status;
+ } __attribute__ ((packed));
+ 
+ struct efi_getnexthighmonotoniccount {
+ 	uint32_t	*HighCount;
+-	uint64_t	*status;
++	efi_status_t	*status;
+ } __attribute__ ((packed));
+ 
+ struct efi_querycapsulecapabilities {
+@@ -127,7 +129,7 @@ struct efi_querycapsulecapabilities {
+ 	uint64_t		CapsuleCount;
+ 	uint64_t		*MaximumCapsuleSize;
+ 	EFI_RESET_TYPE		*ResetType;
+-	uint64_t		*status;
++	efi_status_t		*status;
+ } __attribute__ ((packed));
+ 
+ /* ioctl calls that are permitted to the /dev/efi_runtime interface. */
+diff --git a/src/lib/include/fwts_uefi.h b/src/lib/include/fwts_uefi.h
+index cf9df519..4e348217 100644
+--- a/src/lib/include/fwts_uefi.h
++++ b/src/lib/include/fwts_uefi.h
+@@ -32,12 +32,14 @@ PRAGMA_PACK_WARN_OFF
+ 						0xE0, 0x98, 0x03, 0x2B, 0x8C} \
+ }
+ 
++typedef unsigned long efi_status_t;
++
+ typedef struct {
+ 	uint16_t	*varname;
+ 	uint8_t		guid[16];
+ 	size_t		datalen;
+ 	uint8_t		*data;
+-	uint64_t	status;
++	efi_status_t	status;
+ 	uint32_t	attributes;
+ } fwts_uefi_var;
+ 
+@@ -677,7 +679,7 @@ void fwts_uefi_free_variable(fwts_uefi_var *var);
+ void fwts_uefi_free_variable_names(fwts_list *list);
+ int fwts_uefi_get_variable_names(fwts_list *list);
+ 
+-void fwts_uefi_print_status_info(fwts_framework *fw, const uint64_t status);
++void fwts_uefi_print_status_info(fwts_framework *fw, const efi_status_t status);
+ char *fwts_uefi_attribute_info(uint32_t attr);
+ 
+ bool fwts_uefi_efivars_iface_exist(void);
+diff --git a/src/lib/src/Makefile.am b/src/lib/src/Makefile.am
+index a4fd23e9..d72d87a4 100644
+--- a/src/lib/src/Makefile.am
++++ b/src/lib/src/Makefile.am
+@@ -18,25 +18,19 @@
+ 
+ AM_CPPFLAGS = \
+ 	-I$(top_srcdir)/src/lib/include 		\
+-	-I$(top_srcdir)/src/libfwtsiasl			\
+-	-I$(top_srcdir)/src/acpica/source/include	\
+-	-I$(top_srcdir)/src/acpica/source/compiler	\
+ 	`pkg-config --silence-errors --cflags json`	\
+ 	`pkg-config --silence-errors --cflags json-c`	\
+-	`pkg-config --cflags glib-2.0 gio-2.0` 		\
+ 	-DDATAROOTDIR=\"$(datarootdir)\"		\
+-	-Wall -Werror -Wextra				\
++	-Wall -Wextra			        	\
+ 	-Wno-address-of-packed-member
+ 
+ pkglib_LTLIBRARIES = libfwts.la
+ 
+ libfwts_la_LDFLAGS = 					\
+-	-lm -lpthread -lbsd				\
+-	-version-info 1:0:0 				\
+-	-L$(top_builddir)/src/libfwtsiasl		\
+-	-lfwtsiasl `pkg-config --libs glib-2.0 gio-2.0`
++	-lm -lpthread    				\
++	-version-info 1:0:0
+ 
+-libfwts_la_CPPFLAGS = $(AM_CPPFLAGS) -DACPI_DEBUG_OUTPUT
++libfwts_la_CPPFLAGS = $(AM_CPPFLAGS)
+ 
+ if HAVE_LIBFDT
+ dt_sources = \
+@@ -47,24 +41,13 @@ endif
+ #  Components of the fwts core helper library libfwts
+ #
+ libfwts_la_SOURCES = 		\
+-	fwts_ac_adapter.c 	\
+-	fwts_acpi_object_eval.c \
+-	fwts_acpi_tables.c 	\
+-	fwts_acpi.c 		\
+-	fwts_acpid.c 		\
+ 	fwts_alloc.c 		\
+ 	fwts_arch.c 		\
+ 	fwts_args.c 		\
+ 	fwts_backtrace.c	\
+-	fwts_battery.c 		\
+ 	fwts_binpaths.c 	\
+-	fwts_button.c 		\
+ 	fwts_checkeuid.c 	\
+ 	fwts_checksum.c 	\
+-	fwts_clog.c		\
+-	fwts_cmos.c 		\
+-	fwts_coreboot.c		\
+-	fwts_coreboot_cbmem.c	\
+ 	fwts_cpu.c 		\
+ 	fwts_dump.c 		\
+ 	fwts_dump_data.c 	\
+@@ -77,13 +60,9 @@ libfwts_la_SOURCES = 		\
+ 	fwts_get.c 		\
+ 	fwts_gpe.c 		\
+ 	fwts_guid.c 		\
+-	fwts_hwinfo.c 		\
+-	fwts_iasl.c 		\
+ 	fwts_interactive.c 	\
+ 	fwts_ioport.c		\
+-	fwts_ipmi.c		\
+ 	fwts_json.c		\
+-	fwts_kernel.c 		\
+ 	fwts_keymap.c 		\
+ 	fwts_klog.c 		\
+ 	fwts_olog.c		\
+@@ -99,22 +78,16 @@ libfwts_la_SOURCES = 		\
+ 	fwts_modprobe.c		\
+ 	fwts_multiproc.c 	\
+ 	fwts_oops.c 		\
+-	fwts_pci.c		\
+ 	fwts_pipeio.c 		\
+ 	fwts_release.c		\
+ 	fwts_scan_efi_systab.c 	\
+ 	fwts_set.c 		\
+-	fwts_smbios.c 		\
+ 	fwts_stringextras.c 	\
+ 	fwts_summary.c 		\
+ 	fwts_text_list.c 	\
+-	fwts_tpm.c		\
+ 	fwts_tty.c 		\
+ 	fwts_uefi.c 		\
+-	fwts_wakealarm.c 	\
+-	fwts_pm_method.c	\
+ 	fwts_safe_mem.c		\
+-	fwts_pm_debug.c		\
+ 	$(dt_sources)
+ 
+ -include $(top_srcdir)/git.mk
+diff --git a/src/lib/src/fwts_fileio.c b/src/lib/src/fwts_fileio.c
+index 83a62bc4..eac7fdec 100644
+--- a/src/lib/src/fwts_fileio.c
++++ b/src/lib/src/fwts_fileio.c
+@@ -62,41 +62,3 @@ fwts_list* fwts_file_open_and_read(const char *file)
+ 
+ 	return list;
+ }
+-
+-/*
+- *  fwts_gzfile_read()
+- *	read given gz file and return contents as a list of lines
+- */
+-fwts_list *fwts_gzfile_read(gzFile *fp)
+-{
+-	fwts_list *list;
+-	char buffer[8192];
+-
+-	if ((list = fwts_list_new()) == NULL)
+-		return NULL;
+-
+-	while (gzgets(*fp, buffer, sizeof(buffer)) != NULL) {
+-		buffer[strlen(buffer) - 1] = '\0';	/* Chop off "\n" */
+-		fwts_text_list_append(list, buffer);
+-	}
+-
+-	return list;
+-}
+-
+-/*
+- *  fwts_gzfile_open_and_read()
+- *	open and read gz file and return contents as a list of lines
+- */
+-fwts_list* fwts_gzfile_open_and_read(const char *file)
+-{
+-	gzFile fp;
+-	fwts_list *list;
+-
+-	if ((fp = gzopen(file, "r")) == Z_NULL)
+-		return NULL;
+-
+-	list = fwts_gzfile_read(&fp);
+-	(void)gzclose(fp);
+-
+-	return list;
+-}
+diff --git a/src/lib/src/fwts_framework.c b/src/lib/src/fwts_framework.c
+index 725a7e0b..1ed17432 100644
+--- a/src/lib/src/fwts_framework.c
++++ b/src/lib/src/fwts_framework.c
+@@ -31,7 +31,6 @@
+ #include <sys/time.h>
+ 
+ #include "fwts.h"
+-#include "fwts_pm_method.h"
+ 
+ 
+ #define ACS_VERSION "v1.0"
+diff --git a/src/lib/src/fwts_uefi.c b/src/lib/src/fwts_uefi.c
+index 2dd1727e..61aa7b9d 100644
+--- a/src/lib/src/fwts_uefi.c
++++ b/src/lib/src/fwts_uefi.c
+@@ -41,7 +41,7 @@ typedef struct {
+ 	uint8_t		guid[16];
+ 	uint64_t	datalen;
+ 	uint8_t		data[1024];
+-	uint64_t	status;
++	efi_status_t	status;
+ 	uint32_t	attributes;
+ } __attribute__((packed)) fwts_uefi_sys_fs_var;
+ 
+@@ -52,7 +52,7 @@ typedef struct {
+ } __attribute__((packed)) fwts_uefi_efivars_fs_var;
+ 
+ typedef struct {
+-	const uint64_t statusvalue;
++	const efi_status_t statusvalue;
+ 	const char *mnemonic ;
+ 	const char *description;
+ } uefistatus_info;
+@@ -467,12 +467,12 @@ static const uefistatus_info uefistatus_info_table[] = {
+ 	{ ~0, NULL, NULL }
+ };
+ 
+-void fwts_uefi_print_status_info(fwts_framework *fw, const uint64_t status)
++void fwts_uefi_print_status_info(fwts_framework *fw, const efi_status_t status)
+ {
+ 
+ 	const uefistatus_info *info;
+ 
+-	if (status == ~0ULL) {
++	if (status == ~0UL) {
+ 		fwts_log_info(fw, "fwts test ioctl() failed, errno=%d (%s)", errno, strerror(errno));
+ 		return;
+ 	}
+@@ -483,7 +483,7 @@ void fwts_uefi_print_status_info(fwts_framework *fw, const uint64_t status)
+ 			return;
+ 		}
+ 	}
+-	fwts_log_info(fw, "Cannot find the return status information, value = 0x%" PRIx64 ".", status);
++	fwts_log_info(fw, "Cannot find the return status information, value = 0x%lx.", status);
+ 
+ }
+ 
+diff --git a/src/uefi/securebootcert/securebootcert.c b/src/uefi/securebootcert/securebootcert.c
+index 0fcc771c..21a7935a 100644
+--- a/src/uefi/securebootcert/securebootcert.c
++++ b/src/uefi/securebootcert/securebootcert.c
+@@ -518,7 +518,7 @@ static int securebootcert_setvar(
+ 	long ioret;
+ 	struct efi_setvariable setvariable;
+ 
+-	uint64_t status = ~0ULL;
++	efi_status_t status = ~0UL;
+ 	uint64_t datasize = 1;
+ 
+ 	setvariable.VariableName = varname;
+diff --git a/src/uefi/uefirtauthvar/uefirtauthvar.c b/src/uefi/uefirtauthvar/uefirtauthvar.c
+index 99918125..97c3a7ed 100644
+--- a/src/uefi/uefirtauthvar/uefirtauthvar.c
++++ b/src/uefi/uefirtauthvar/uefirtauthvar.c
+@@ -61,7 +61,7 @@ static long setvar(
+ 	uint32_t var_attributes,
+ 	uint64_t datasize,
+ 	void *data,
+-	uint64_t *status)
++	efi_status_t *status)
+ {
+ 	long ioret;
+ 	struct efi_setvariable setvariable;
+@@ -72,7 +72,7 @@ static long setvar(
+ 	setvariable.DataSize = datasize;
+ 	setvariable.Data = data;
+ 	setvariable.status = status;
+-	*status = ~0ULL;
++	*status = ~0UL;
+ 	ioret = ioctl(fd, EFI_RUNTIME_SET_VARIABLE, &setvariable);
+ 
+ 	return ioret;
+@@ -83,7 +83,7 @@ static long getvar(
+ 	uint32_t *attributestest,
+ 	uint64_t *getdatasize,
+ 	void *data,
+-	uint64_t *status)
++	efi_status_t *status)
+ {
+ 	long ioret;
+ 	struct efi_getvariable getvariable;
+@@ -94,7 +94,7 @@ static long getvar(
+ 	getvariable.DataSize = getdatasize;
+ 	getvariable.Data = data;
+ 	getvariable.status = status;
+-	*status = ~0ULL;
++	*status = ~0UL;
+ 	ioret = ioctl(fd, EFI_RUNTIME_GET_VARIABLE, &getvariable);
+ 
+ 	return ioret;
+@@ -102,7 +102,7 @@ static long getvar(
+ 
+ static void uefirtvariable_env_cleanup(void)
+ {
+-	uint64_t status;
++	efi_status_t status;
+ 	uint8_t data[GETVAR_BUF_SIZE];
+ 	uint64_t getdatasize = sizeof(data);
+ 	uint32_t attributestest;
+@@ -145,7 +145,7 @@ static int uefirtauthvar_deinit(fwts_framework *fw)
+ 	return FWTS_OK;
+ }
+ 
+-static int check_fw_support(fwts_framework *fw, uint64_t status)
++static int check_fw_support(fwts_framework *fw, efi_status_t status)
+ {
+ 	if ((status == EFI_INVALID_PARAMETER) &&
+ 		((bool)(attributes & FWTS_UEFI_VARIABLE_AUTHENTICATED_WRITE_ACCESS) ||
+@@ -186,7 +186,7 @@ static int uefirtauthvar_test1(fwts_framework *fw)
+ 
+ 	uint8_t data[GETVAR_BUF_SIZE];
+ 	uint64_t getdatasize = sizeof(data);
+-	uint64_t status;
++	efi_status_t status;
+ 	uint32_t attributestest;
+ 	size_t i;
+ 
+@@ -248,7 +248,7 @@ static int uefirtauthvar_test1(fwts_framework *fw)
+ static int uefirtauthvar_test2(fwts_framework *fw)
+ {
+ 	long ioret;
+-	uint64_t status;
++	efi_status_t status;
+ 
+ 	if (!(data_exist & E_AUTHVARCREATE)) {
+ 		fwts_skipped(fw,"The test variable, AuthVarCreate, doesn't exist, skip the test.");
+@@ -288,7 +288,7 @@ static int uefirtauthvar_test2(fwts_framework *fw)
+ static int uefirtauthvar_test3(fwts_framework *fw)
+ {
+ 	long ioret;
+-	uint64_t status;
++	efi_status_t status;
+ 
+ 	if (!(data_exist & E_AUTHVARCREATE)) {
+ 		fwts_skipped(fw,"The test variable, AuthVarCreate, doesn't exist, skip the test.");
+@@ -330,7 +330,7 @@ static int uefirtauthvar_test4(fwts_framework *fw)
+ 
+ 	uint8_t data[GETVAR_BUF_SIZE];
+ 	uint64_t getdatasize = sizeof(data);
+-	uint64_t status;
++	efi_status_t status;
+ 	uint32_t attributestest;
+ 	size_t i;
+ 	uint32_t attribappend = attributes | FWTS_UEFI_VARIABLE_APPEND_WRITE;
+@@ -412,7 +412,7 @@ static int uefirtauthvar_test5(fwts_framework *fw)
+ 
+ 	uint8_t data[GETVAR_BUF_SIZE];
+ 	uint64_t getdatasize = sizeof(data);
+-	uint64_t status;
++	efi_status_t status;
+ 	uint32_t attributestest;
+ 	size_t i;
+ 
+@@ -480,7 +480,7 @@ static int uefirtauthvar_test5(fwts_framework *fw)
+ static int uefirtauthvar_test6(fwts_framework *fw)
+ {
+ 	long ioret;
+-	uint64_t status;
++	efi_status_t status;
+ 
+ 	if (!(data_exist & E_AUTHVARUPDATE)) {
+ 		fwts_skipped(fw,"The test variable, AuthVarUpdate, doesn't exist, skip the test.");
+@@ -522,7 +522,7 @@ static int uefirtauthvar_test7(fwts_framework *fw)
+ 
+ 	uint8_t data[GETVAR_BUF_SIZE];
+ 	uint64_t getdatasize = sizeof(data);
+-	uint64_t status;
++	efi_status_t status;
+ 	uint32_t attributestest;
+ 
+ 	if (!(data_exist & E_AUTHVARCREATE)) {
+@@ -576,7 +576,7 @@ static int uefirtauthvar_test7(fwts_framework *fw)
+ static int uefirtauthvar_test8(fwts_framework *fw)
+ {
+ 	long ioret;
+-	uint64_t status;
++	efi_status_t status;
+ 
+ 	ioret = setvar(&gtestguid, attributes, sizeof(AuthVarModData), AuthVarModData, &status);
+ 
+@@ -611,7 +611,7 @@ static int uefirtauthvar_test8(fwts_framework *fw)
+ static int uefirtauthvar_test9(fwts_framework *fw)
+ {
+ 	long ioret;
+-	uint64_t status;
++	efi_status_t status;
+ 
+ 	ioret = setvar(&gtestguid, attributes, sizeof(AuthVarModTime), AuthVarModTime, &status);
+ 
+@@ -646,7 +646,7 @@ static int uefirtauthvar_test9(fwts_framework *fw)
+ static int uefirtauthvar_test10(fwts_framework *fw)
+ {
+ 	long ioret;
+-	uint64_t status;
++	efi_status_t status;
+ 	EFI_GUID gtestguiddiff = TEST_GUID1;
+ 
+ 	ioret = setvar(&gtestguiddiff, attributes, sizeof(AuthVarCreate), AuthVarCreate, &status);
+@@ -685,7 +685,7 @@ static int uefirtauthvar_test11(fwts_framework *fw)
+ 
+ 	uint8_t data[GETVAR_BUF_SIZE];
+ 	uint64_t getdatasize = sizeof(data);
+-	uint64_t status;
++	efi_status_t status;
+ 	uint32_t attributestest;
+ 	size_t i;
+ 
+diff --git a/src/uefi/uefirtmisc/uefirtmisc.c b/src/uefi/uefirtmisc/uefirtmisc.c
+index 28939fb0..ab54929f 100644
+--- a/src/uefi/uefirtmisc/uefirtmisc.c
++++ b/src/uefi/uefirtmisc/uefirtmisc.c
+@@ -70,7 +70,7 @@ static int uefirtmisc_deinit(fwts_framework *fw)
+ 
+ static int getnexthighmonotoniccount_test(fwts_framework *fw, uint32_t multitesttime)
+ {
+-	uint64_t status;
++	efi_status_t status;
+ 	struct efi_getnexthighmonotoniccount getnexthighmonotoniccount;
+ 	uint32_t highcount;
+ 	uint32_t i;
+@@ -85,7 +85,7 @@ static int getnexthighmonotoniccount_test(fwts_framework *fw, uint32_t multitest
+ 	getnexthighmonotoniccount.status = &status;
+ 
+ 	for (i = 0; i < multitesttime; i++) {
+-		status = ~0ULL;
++		status = ~0UL;
+ 		long ioret = ioctl(fd, EFI_RUNTIME_GET_NEXTHIGHMONOTONICCOUNT, &getnexthighmonotoniccount);
+ 
+ 		if (ioret == -1) {
+@@ -111,7 +111,7 @@ static int getnexthighmonotoniccount_test(fwts_framework *fw, uint32_t multitest
+ 
+ static int querycapsulecapabilities_test(fwts_framework *fw, uint32_t multitesttime, uint32_t flag)
+ {
+-	uint64_t status;
++	efi_status_t status;
+ 	uint32_t i;
+ 
+ 	struct efi_querycapsulecapabilities querycapsulecapabilities;
+@@ -143,7 +143,7 @@ static int querycapsulecapabilities_test(fwts_framework *fw, uint32_t multitestt
+ 	querycapsulecapabilities.ResetType = &resettype;
+ 
+ 	for (i = 0; i < multitesttime; i++) {
+-		status = ~0ULL;
++		status = ~0UL;
+ 		long ioret = ioctl(fd, EFI_RUNTIME_QUERY_CAPSULECAPABILITIES, &querycapsulecapabilities);
+ 		if (ioret == -1) {
+ 			if (status == EFI_UNSUPPORTED) {
+@@ -254,7 +254,7 @@ static int uefirtmisc_test2(fwts_framework *fw)
+ 
+ static int uefirtmisc_test3(fwts_framework *fw)
+ {
+-	uint64_t status = ~0ULL;
++	efi_status_t status = ~0UL;
+ 	long ioret;
+ 	struct efi_getnexthighmonotoniccount getnexthighmonotoniccount;
+ 
+@@ -294,13 +294,13 @@ static int uefirtmisc_test4(fwts_framework *fw)
+ 
+ 	if (!(runtimeservicessupported & EFI_RT_SUPPORTED_GET_NEXT_HIGH_MONOTONIC_COUNT)) {
+ 		long ioret;
+-		uint64_t status;
++		efi_status_t status;
+ 		struct efi_getnexthighmonotoniccount getnexthighmonotoniccount;
+ 		uint32_t highcount;
+ 
+ 		getnexthighmonotoniccount.HighCount = &highcount;
+ 		getnexthighmonotoniccount.status = &status;
+-		status = ~0ULL;
++		status = ~0UL;
+ 
+ 		ioret = ioctl(fd, EFI_RUNTIME_GET_NEXTHIGHMONOTONICCOUNT, &getnexthighmonotoniccount);
+ 		if (ioret == -1) {
+@@ -308,7 +308,7 @@ static int uefirtmisc_test4(fwts_framework *fw)
+ 				fwts_passed(fw, "UEFI GetNextHighMonotonicCount runtime "
+ 					"service unsupported status test passed.");
+ 			else {
+-				if (status == ~0ULL) {
++				if (status == ~0UL) {
+ 					fwts_skipped(fw, "Unknown error occurred, skip test.");
+ 					return FWTS_SKIP;
+ 				} else {
+diff --git a/src/uefi/uefirttime/uefirttime.c b/src/uefi/uefirttime/uefirttime.c
+index 0cb50e8b..3c63953d 100644
+--- a/src/uefi/uefirttime/uefirttime.c
++++ b/src/uefi/uefirttime/uefirttime.c
+@@ -198,7 +198,7 @@ static int uefirttime_test1(fwts_framework *fw)
+ 	EFI_TIME efi_time;
+ 
+ 	EFI_TIME_CAPABILITIES efi_time_cap;
+-	uint64_t status = ~0ULL;
++	efi_status_t status = ~0UL;
+ 
+ 	if (!(runtimeservicessupported & EFI_RT_SUPPORTED_GET_TIME)) {
+ 		fwts_skipped(fw, "Skipping test, GetTime runtime "
+@@ -239,7 +239,7 @@ static int uefirttime_test_gettime_invalid(
+ {
+ 	long ioret;
+ 	struct efi_gettime gettime;
+-	uint64_t status = ~0ULL;
++	efi_status_t status = ~0UL;
+ 
+ 	if (!(runtimeservicessupported & EFI_RT_SUPPORTED_GET_TIME)) {
+ 		fwts_skipped(fw, "Skipping test, GetTime runtime "
+@@ -291,7 +291,7 @@ static int uefirttime_test4(fwts_framework *fw)
+ 
+ 	long ioret;
+ 	struct efi_settime settime;
+-	uint64_t status = ~0ULL;
++	efi_status_t status = ~0UL;
+ 	struct efi_gettime gettime;
+ 
+ 	EFI_TIME oldtime;
+@@ -356,7 +356,7 @@ static int uefirttime_test4(fwts_framework *fw)
+ 	}
+ 
+ 	settime.Time = &time;
+-	status = ~0ULL;
++	status = ~0UL;
+ 	settime.status = &status;
+ 
+ 	ioret = ioctl(fd, EFI_RUNTIME_SET_TIME, &settime);
+@@ -375,7 +375,7 @@ static int uefirttime_test4(fwts_framework *fw)
+ 	sleep(1);
+ 
+ 	gettime.Time = &newtime;
+-	status = ~0ULL;
++	status = ~0UL;
+ 
+ 	ioret = ioctl(fd, EFI_RUNTIME_GET_TIME, &gettime);
+ 
+@@ -428,7 +428,7 @@ static int uefirttime_test4(fwts_framework *fw)
+ 
+ 	/* restore the previous time. */
+ 	settime.Time = &oldtime;
+-	status = ~0ULL;
++	status = ~0UL;
+ 	ioret = ioctl(fd, EFI_RUNTIME_SET_TIME, &settime);
+ 	if (ioret == -1) {
+ 		if (status == EFI_UNSUPPORTED) {
+@@ -452,7 +452,7 @@ static int uefirttime_test_settime_invalid(
+ 	struct efi_settime *settime)
+ {
+ 	long ioret;
+-	static uint64_t status;
++	static efi_status_t status;
+ 
+ 	if (!(runtimeservicessupported & EFI_RT_SUPPORTED_SET_TIME)) {
+ 		fwts_skipped(fw, "Skipping test, SetTime runtime "
+@@ -460,7 +460,7 @@ static int uefirttime_test_settime_invalid(
+ 		return FWTS_SKIP;
+ 	}
+ 
+-	status = ~0ULL;
++	status = ~0UL;
+ 	settime->status = &status;
+ 
+ 	ioret = ioctl(fd, EFI_RUNTIME_SET_TIME, settime);
+@@ -493,7 +493,7 @@ static int uefirttime_test_settime_invalid_time(
+ 	struct efi_gettime gettime;
+ 	struct efi_settime settime;
+ 	EFI_TIME oldtime, newtime;
+-	uint64_t status = ~0ULL;
++	efi_status_t status = ~0UL;
+ 	int ret, ioret;
+ 
+ 	if (!(runtimeservicessupported & EFI_RT_SUPPORTED_GET_TIME)) {
+@@ -547,7 +547,7 @@ static int uefirttime_test_settime_invalid_time(
+ 
+ 	/* Restore original time */
+ 	settime.Time = &oldtime;
+-	status = ~0ULL;
++	status = ~0UL;
+ 	settime.status = &status;
+ 	ioret = ioctl(fd, EFI_RUNTIME_SET_TIME, &settime);
+ 	if (ioret == -1) {
+@@ -695,7 +695,7 @@ static int uefirttime_test18(fwts_framework *fw)
+ {
+ 	long ioret;
+ 	struct efi_getwakeuptime getwakeuptime;
+-	uint64_t status = ~0ULL;
++	efi_status_t status = ~0UL;
+ 	uint8_t enabled, pending;
+ 	EFI_TIME efi_time;
+ 
+@@ -736,7 +736,7 @@ static int uefirttime_test_getwaketime_invalid(
+ 	struct efi_getwakeuptime *getwakeuptime)
+ {
+ 	long ioret;
+-	static uint64_t status;
++	static efi_status_t status;
+ 
+ 	if (!(runtimeservicessupported & EFI_RT_SUPPORTED_GET_WAKEUP_TIME)) {
+ 		fwts_skipped(fw, "Skipping test, GetWakeupTime runtime "
+@@ -744,7 +744,7 @@ static int uefirttime_test_getwaketime_invalid(
+ 		return FWTS_SKIP;
+ 	}
+ 
+-	status = ~0ULL;
++	status = ~0UL;
+ 	getwakeuptime->status = &status;
+ 
+ 	ioret = ioctl(fd, EFI_RUNTIME_GET_WAKETIME, getwakeuptime);
+@@ -824,7 +824,7 @@ static int uefirttime_test23(fwts_framework *fw)
+ {
+ 	long ioret;
+ 	struct efi_setwakeuptime setwakeuptime;
+-	uint64_t status = ~0ULL;
++	efi_status_t status = ~0UL;
+ 	EFI_TIME oldtime;
+ 	EFI_TIME newtime;
+ 
+@@ -868,7 +868,7 @@ static int uefirttime_test23(fwts_framework *fw)
+ 	addonehour(&oldtime);
+ 
+ 	setwakeuptime.Time = &oldtime;
+-	status = ~0ULL;
++	status = ~0UL;
+ 	setwakeuptime.status = &status;
+ 	setwakeuptime.Enabled = true;
+ 
+@@ -896,7 +896,7 @@ static int uefirttime_test23(fwts_framework *fw)
+ 	getwakeuptime.Enabled = &enabled;
+ 	getwakeuptime.Pending = &pending;
+ 	getwakeuptime.Time = &newtime;
+-	status = ~0ULL;
++	status = ~0UL;
+ 	getwakeuptime.status = &status;
+ 
+ 	ioret = ioctl(fd, EFI_RUNTIME_GET_WAKETIME, &getwakeuptime);
+@@ -932,7 +932,7 @@ static int uefirttime_test23(fwts_framework *fw)
+ 	}
+ 
+ 	setwakeuptime.Enabled = false;
+-	status = ~0ULL;
++	status = ~0UL;
+ 
+ 	ioret = ioctl(fd, EFI_RUNTIME_SET_WAKETIME, &setwakeuptime);
+ 	if (ioret == -1) {
+@@ -948,7 +948,7 @@ static int uefirttime_test23(fwts_framework *fw)
+ 	}
+ 
+ 	sleep(1);
+-	status = ~0ULL;
++	status = ~0UL;
+ 
+ 	ioret = ioctl(fd, EFI_RUNTIME_GET_WAKETIME, &getwakeuptime);
+ 	if (ioret == -1) {
+@@ -980,7 +980,7 @@ static int uefirttime_test_setwakeuptime_invalid(
+ )
+ {
+ 	long ioret;
+-	static uint64_t status;
++	static efi_status_t status;
+ 
+ 	if (!(runtimeservicessupported & EFI_RT_SUPPORTED_SET_WAKEUP_TIME)) {
+ 		fwts_skipped(fw, "Skipping test, SetWakeupTime runtime "
+@@ -988,7 +988,7 @@ static int uefirttime_test_setwakeuptime_invalid(
+ 		return FWTS_SKIP;
+ 	}
+ 
+-	status = ~0ULL;
++	status = ~0UL;
+ 	setwakeuptime->status = &status;
+ 
+ 	ioret = ioctl(fd, EFI_RUNTIME_SET_WAKETIME, setwakeuptime);
+@@ -1031,7 +1031,7 @@ static int uefirttime_test_setwakeuptime_invalid_time(
+ 	struct efi_getwakeuptime getwakeuptime;
+ 	struct efi_setwakeuptime setwakeuptime;
+ 	EFI_TIME oldtime, newtime;
+-	uint64_t status = ~0ULL;
++	efi_status_t status = ~0UL;
+ 	uint8_t pending, enabled;
+ 	int ret, ioret;
+ 
+@@ -1088,7 +1088,7 @@ static int uefirttime_test_setwakeuptime_invalid_time(
+ 
+ 	/* Restore original time */
+ 	setwakeuptime.Time = &oldtime;
+-	status = ~0ULL;
++	status = ~0UL;
+ 	setwakeuptime.status = &status;
+ 	setwakeuptime.Enabled = true;
+ 	ioret = ioctl(fd, EFI_RUNTIME_SET_WAKETIME, &setwakeuptime);
+@@ -1238,7 +1238,7 @@ static int uefirttime_test38(fwts_framework *fw)
+ 	long ioret;
+ 
+ 	struct efi_settime settime;
+-	uint64_t status = ~0ULL;
++	efi_status_t status = ~0UL;
+ 	struct efi_gettime gettime;
+ 	struct efi_getwakeuptime getwakeuptime;
+ 	uint8_t enabled, pending;
+@@ -1258,7 +1258,7 @@ static int uefirttime_test38(fwts_framework *fw)
+ 				fwts_passed(fw, "UEFI GetTime runtime service "
+ 					"unsupported status test passed.");
+ 			else {
+-				if (status == ~0ULL)
++				if (status == ~0UL)
+ 					fwts_skipped(fw, "Unknown error occurred, skip test.");
+ 				else
+ 					fwts_failed(fw, LOG_LEVEL_HIGH, "UEFIRuntimeGetTime",
+@@ -1286,7 +1286,7 @@ static int uefirttime_test38(fwts_framework *fw)
+ 
+ 	if (!(runtimeservicessupported & EFI_RT_SUPPORTED_SET_TIME)) {
+ 		settime.Time = &efi_time;
+-		status = ~0ULL;
++		status = ~0UL;
+ 		settime.status = &status;
+ 
+ 		ioret = ioctl(fd, EFI_RUNTIME_SET_TIME, &settime);
+@@ -1295,7 +1295,7 @@ static int uefirttime_test38(fwts_framework *fw)
+ 				fwts_passed(fw, "UEFI SetTime runtime service "
+ 					"unsupported status test passed.");
+ 			} else {
+-				if (status == ~0ULL)
++				if (status == ~0UL)
+ 					fwts_skipped(fw, "Unknown error occurred, skip test.");
+ 				else
+ 					fwts_failed(fw, LOG_LEVEL_HIGH, "UEFIRuntimeSetTime",
+@@ -1317,7 +1317,7 @@ static int uefirttime_test38(fwts_framework *fw)
+ 
+ 	if (!(runtimeservicessupported & EFI_RT_SUPPORTED_SET_WAKEUP_TIME)) {
+ 		setwakeuptime.Time = &efi_time;
+-		status = ~0ULL;
++		status = ~0UL;
+ 		setwakeuptime.status = &status;
+ 		setwakeuptime.Enabled = false;
+ 
+@@ -1327,7 +1327,7 @@ static int uefirttime_test38(fwts_framework *fw)
+ 						fwts_passed(fw, "UEFI SetWakeupTime runtime service "
+ 							"unsupported status test passed.");
+ 			else {
+-				if (status == ~0ULL)
++				if (status == ~0UL)
+ 					fwts_skipped(fw, "Unknown error occurred, skip test.");
+ 				else
+ 					fwts_failed(fw, LOG_LEVEL_HIGH, "UEFIRuntimeSetWakeupTime",
+@@ -1360,7 +1360,7 @@ static int uefirttime_test38(fwts_framework *fw)
+ 					fwts_passed(fw, "UEFI GetWakeupTime runtime service "
+ 						"unsupported status test passed.");
+ 			else {
+-				if (status == ~0ULL)
++				if (status == ~0UL)
+ 					fwts_skipped(fw, "Unknown error occurred, skip test.");
+ 				else
+ 					fwts_failed(fw, LOG_LEVEL_HIGH, "UEFIRuntimeGetWakeupTime",
+diff --git a/src/uefi/uefirtvariable/uefirtvariable.c b/src/uefi/uefirtvariable/uefirtvariable.c
+index bf6f5e89..7c6bb772 100644
+--- a/src/uefi/uefirtvariable/uefirtvariable.c
++++ b/src/uefi/uefirtvariable/uefirtvariable.c
+@@ -69,7 +69,7 @@ static uint32_t runtimeservicessupported;
+ static void uefirtvariable_env_cleanup(void)
+ {
+ 	struct efi_setvariable setvariable;
+-	uint64_t status;
++	efi_status_t status;
+ 	uint8_t data = 0;
+ 
+ 	setvariable.VariableName = variablenametest;
+@@ -77,19 +77,19 @@ static void uefirtvariable_env_cleanup(void)
+ 	setvariable.Attributes = 0;
+ 	setvariable.DataSize = 0;
+ 	setvariable.Data = &data;
+-	status = ~0ULL;
++	status = ~0UL;
+ 	setvariable.status = &status;
+ 	(void)ioctl(fd, EFI_RUNTIME_SET_VARIABLE, &setvariable);
+ 
+-	status = ~0ULL;
++	status = ~0UL;
+ 	setvariable.VariableName = variablenametest2;
+ 	(void)ioctl(fd, EFI_RUNTIME_SET_VARIABLE, &setvariable);
+ 
+-	status = ~0ULL;
++	status = ~0UL;
+ 	setvariable.VariableName = variablenametest3;
+ 	(void)ioctl(fd, EFI_RUNTIME_SET_VARIABLE, &setvariable);
+ 
+-	status = ~0ULL;
++	status = ~0UL;
+ 	setvariable.VariableName = variablenametest;
+ 	setvariable.VendorGuid = &gtestguid2;
+ 	(void)ioctl(fd, EFI_RUNTIME_SET_VARIABLE, &setvariable);
+@@ -125,7 +125,7 @@ static int getvariable_test(
+ 	struct efi_getvariable getvariable;
+ 	struct efi_setvariable setvariable;
+ 
+-	uint64_t status = ~0ULL;
++	efi_status_t status = ~0UL;
+ 	uint8_t testdata[MAX_DATA_LENGTH];
+ 	uint64_t dataindex;
+ 	uint64_t getdatasize = sizeof(testdata);
+@@ -189,7 +189,7 @@ static int getvariable_test(
+ 	getvariable.status = &status;
+ 
+ 	for (i = 0; i < multitesttime; i++) {
+-		status = ~0ULL;
++		status = ~0UL;
+ 		ioret = ioctl(fd, EFI_RUNTIME_GET_VARIABLE, &getvariable);
+ 		if (ioret == -1) {
+ 			if (status == EFI_UNSUPPORTED) {
+@@ -239,7 +239,7 @@ static int getvariable_test(
+ 
+ 	/* delete the variable */
+ 	setvariable.DataSize = 0;
+-	status = ~0ULL;
++	status = ~0UL;
+ 
+ 	ioret = ioctl(fd, EFI_RUNTIME_SET_VARIABLE, &setvariable);
+ 
+@@ -255,7 +255,7 @@ static int getvariable_test(
+ err_restore_env:
+ 
+ 	setvariable.DataSize = 0;
+-	status = ~0ULL;
++	status = ~0UL;
+ 
+ 	ioret = ioctl(fd, EFI_RUNTIME_SET_VARIABLE, &setvariable);
+ 
+@@ -308,7 +308,7 @@ static bool compare_name(const uint16_t *name1, const uint16_t *name2)
+ static int getnextvariable_test1(fwts_framework *fw)
+ {
+ 	long ioret;
+-	uint64_t status = ~0ULL;
++	efi_status_t status = ~0UL;
+ 
+ 	struct efi_setvariable setvariable;
+ 
+@@ -388,7 +388,7 @@ static int getnextvariable_test1(fwts_framework *fw)
+ 	variablename[0] = '\0';
+ 	while (true) {
+ 		variablenamesize = maxvariablenamesize;
+-		status = ~0ULL;
++		status = ~0UL;
+ 		ioret = ioctl(fd, EFI_RUNTIME_GET_NEXTVARIABLENAME, &getnextvariablename);
+ 
+ 		if (ioret == -1) {
+@@ -458,7 +458,7 @@ static int getnextvariable_test1(fwts_framework *fw)
+ 
+ 	/* delete the variable */
+ 	setvariable.DataSize = 0;
+-	status = ~0ULL;
++	status = ~0UL;
+ 
+ 	ioret = ioctl(fd, EFI_RUNTIME_SET_VARIABLE, &setvariable);
+ 
+@@ -474,7 +474,7 @@ static int getnextvariable_test1(fwts_framework *fw)
+ err_restore_env:
+ 
+ 	setvariable.DataSize = 0;
+-	status = ~0ULL;
++	status = ~0UL;
+ 
+ 	ioret = ioctl(fd, EFI_RUNTIME_SET_VARIABLE, &setvariable);
+ 	if (ioret == -1) {
+@@ -512,7 +512,7 @@ static bool strlen_valid(const uint16_t *variablename, const uint64_t variablena
+ 
+ static int getnextvariable_test2(fwts_framework *fw)
+ {
+-	uint64_t status;
++	efi_status_t status;
+ 
+ 	struct efi_getnextvariablename getnextvariablename;
+ 	uint64_t variablenamesize = MAX_DATA_LENGTH;
+@@ -546,7 +546,7 @@ static int getnextvariable_test2(fwts_framework *fw)
+ 	while (true) {
+ 		long ioret;
+ 
+-		status = ~0ULL;
++		status = ~0UL;
+ 		variablenamesize = maxvariablenamesize;
+ 		ioret = ioctl(fd, EFI_RUNTIME_GET_NEXTVARIABLENAME, &getnextvariablename);
+ 
+@@ -683,7 +683,7 @@ static void bucket_destroy(void)
+ static int getnextvariable_test3(fwts_framework *fw)
+ {
+ 	long ioret;
+-	uint64_t status;
++	efi_status_t status;
+ 
+ 	struct efi_getnextvariablename getnextvariablename;
+ 	uint64_t variablenamesize = MAX_DATA_LENGTH;
+@@ -717,7 +717,7 @@ static int getnextvariable_test3(fwts_framework *fw)
+ 	while (true) {
+ 		struct efi_var_item *item;
+ 
+-		status = ~0ULL;
++		status = ~0UL;
+ 		variablenamesize = maxvariablenamesize;
+ 		ioret = ioctl(fd, EFI_RUNTIME_GET_NEXTVARIABLENAME, &getnextvariablename);
+ 
+@@ -823,7 +823,7 @@ err:
+ static int getnextvariable_test4(fwts_framework *fw)
+ {
+ 	long ioret;
+-	uint64_t status = ~0ULL;
++	efi_status_t status = ~0UL;
+ 	uint64_t i;
+ 
+ 	struct efi_getnextvariablename getnextvariablename;
+@@ -866,7 +866,7 @@ static int getnextvariable_test4(fwts_framework *fw)
+ 
+ 	getnextvariablename.VariableName = variablename;
+ 	getnextvariablename.VendorGuid = NULL;
+-	status = ~0ULL;
++	status = ~0UL;
+ 
+ 	ioret = ioctl(fd, EFI_RUNTIME_GET_NEXTVARIABLENAME, &getnextvariablename);
+ 
+@@ -880,7 +880,7 @@ static int getnextvariable_test4(fwts_framework *fw)
+ 
+ 	getnextvariablename.VendorGuid = &vendorguid;
+ 	getnextvariablename.VariableNameSize = NULL;
+-	status = ~0ULL;
++	status = ~0UL;
+ 
+ 	ioret = ioctl(fd, EFI_RUNTIME_GET_NEXTVARIABLENAME, &getnextvariablename);
+ 
+@@ -902,7 +902,7 @@ static int getnextvariable_test4(fwts_framework *fw)
+ 		 * string in VariableName
+ 		 */
+ 		variablename[0] = '\0';
+-		status = ~0ULL;
++		status = ~0UL;
+ 
+ 		ioret = ioctl(fd, EFI_RUNTIME_GET_NEXTVARIABLENAME, &getnextvariablename);
+ 
+@@ -949,7 +949,7 @@ static int setvariable_insertvariable(
+ 	long ioret;
+ 	struct efi_setvariable setvariable;
+ 
+-	uint64_t status = ~0ULL;
++	efi_status_t status = ~0UL;
+ 	uint64_t dataindex;
+ 
+ 	uint8_t data[datasize + 1];
+@@ -1029,7 +1029,7 @@ static int setvariable_checkvariable(
+ 	long ioret;
+ 	struct efi_getvariable getvariable;
+ 
+-	uint64_t status = ~0ULL;
++	efi_status_t status = ~0UL;
+ 	uint8_t testdata[datasize];
+ 	uint64_t dataindex;
+ 	uint64_t getdatasize = sizeof(testdata);
+@@ -1096,7 +1096,7 @@ static int setvariable_checkvariable_notfound(
+ 	long ioret;
+ 	struct efi_getvariable getvariable;
+ 
+-	uint64_t status = ~0ULL;
++	efi_status_t status = ~0UL;
+ 	uint8_t testdata[MAX_DATA_LENGTH];
+ 	uint64_t getdatasize = sizeof(testdata);
+ 	uint32_t attributestest;
+@@ -1142,7 +1142,7 @@ static int setvariable_invalidattr(
+ {
+ 	long ioret;
+ 	struct efi_setvariable setvariable;
+-	uint64_t status = ~0ULL;
++	efi_status_t status = ~0UL;
+ 	uint64_t dataindex;
+ 	uint8_t data[datasize];
+ 
+@@ -1502,7 +1502,7 @@ static int setvariable_test8(fwts_framework *fw)
+ 	uint32_t attr = attributes | FWTS_UEFI_VARIABLE_AUTHENTICATED_WRITE_ACCESS;
+ 	uint64_t datasize = 1;
+ 	uint8_t data = 1;
+-	uint64_t status = ~0ULL;
++	efi_status_t status = ~0UL;
+ 
+ 	if (!(runtimeservicessupported & EFI_RT_SUPPORTED_SET_VARIABLE)) {
+ 		fwts_skipped(fw, "Skipping test, SetVariable runtime service "
+@@ -1532,7 +1532,7 @@ static int setvariable_test8(fwts_framework *fw)
+ }
+ 
+ static int do_queryvariableinfo(
+-	uint64_t *status,
++	efi_status_t *status,
+ 	uint64_t *remvarstoragesize,
+ 	uint64_t *maxvariablesize)
+ {
+@@ -1545,7 +1545,7 @@ static int do_queryvariableinfo(
+ 	queryvariableinfo.RemainingVariableStorageSize = remvarstoragesize;
+ 	queryvariableinfo.MaximumVariableSize = maxvariablesize;
+ 	queryvariableinfo.status = status;
+-	*status = ~0ULL;
++	*status = ~0UL;
+ 
+ 	ioret = ioctl(fd, EFI_RUNTIME_QUERY_VARIABLEINFO, &queryvariableinfo);
+ 
+@@ -1560,7 +1560,7 @@ static int getnextvariable_multitest(
+ 	const uint32_t multitesttime)
+ {
+ 	long ioret;
+-	uint64_t status = ~0ULL;
++	efi_status_t status = ~0UL;
+ 	uint32_t i;
+ 
+ 	struct efi_setvariable setvariable;
+@@ -1627,7 +1627,7 @@ static int getnextvariable_multitest(
+ 	for (i = 0; i < multitesttime; i++) {
+ 		variablename[0] = '\0';
+ 		variablenamesize = MAX_DATA_LENGTH;
+-		status = ~0ULL;
++		status = ~0UL;
+ 		ioret = ioctl(fd, EFI_RUNTIME_GET_NEXTVARIABLENAME, &getnextvariablename);
+ 
+ 		if (ioret == -1) {
+@@ -1645,7 +1645,7 @@ static int getnextvariable_multitest(
+ 	};
+ 
+ 	setvariable.DataSize = 0;
+-	status = ~0ULL;
++	status = ~0UL;
+ 
+ 	ioret = ioctl(fd, EFI_RUNTIME_SET_VARIABLE, &setvariable);
+ 
+@@ -1660,7 +1660,7 @@ static int getnextvariable_multitest(
+ err_restore_env:
+ 
+ 	setvariable.DataSize = 0;
+-	status = ~0ULL;
++	status = ~0UL;
+ 
+ 	ioret = ioctl(fd, EFI_RUNTIME_SET_VARIABLE, &setvariable);
+ 
+@@ -1778,7 +1778,7 @@ static int uefirtvariable_test3(fwts_framework *fw)
+ 
+ static int uefirtvariable_test4(fwts_framework *fw)
+ {
+-	uint64_t status;
++	efi_status_t status;
+ 	uint64_t remvarstoragesize;
+ 	uint64_t maxvariablesize;
+ 
+@@ -1929,7 +1929,7 @@ static int uefirtvariable_test6(fwts_framework *fw)
+ static int uefirtvariable_test7(fwts_framework *fw)
+ {
+ 	uint32_t multitesttime = uefi_query_variable_multiple;
+-	uint64_t status;
++	efi_status_t status;
+ 	uint64_t remvarstoragesize;
+ 	uint64_t maxvariablesize;
+ 	uint32_t i;
+@@ -1994,7 +1994,7 @@ static void getvariable_test_invalid(
+ 	}
+ 
+ 	fwts_log_info(fw, "Testing GetVariable with %s.", test);
+-	*(getvariable->status) = ~0ULL;
++	*(getvariable->status) = ~0UL;
+ 
+ 	ioret = ioctl(fd, EFI_RUNTIME_GET_VARIABLE, getvariable);
+ 
+@@ -2030,7 +2030,7 @@ static int uefirtvariable_test8(fwts_framework *fw)
+ 	struct efi_getvariable getvariable;
+ 	struct efi_setvariable setvariable;
+ 	uint8_t data[16];
+-	uint64_t status= ~0ULL;
++	efi_status_t status= ~0UL;
+         uint64_t dataindex;
+ 	uint64_t getdatasize = sizeof(data);
+ 	uint32_t attr;
+@@ -2118,7 +2118,7 @@ static int uefirtvariable_test8(fwts_framework *fw)
+ 
+ 	/* delete the variable */
+ 	setvariable.DataSize = 0;
+-	status = ~0ULL;
++	status = ~0UL;
+ 	ioret = ioctl(fd, EFI_RUNTIME_SET_VARIABLE, &setvariable);
+ 	if (ioret == -1) {
+ 		fwts_failed(fw, LOG_LEVEL_HIGH, "UEFIRuntimeSetVariable",
+@@ -2139,7 +2139,7 @@ static int uefirtvariable_test9(fwts_framework *fw)
+ 	struct efi_queryvariableinfo queryvariableinfo;
+ 
+ 	EFI_GUID guid;
+-	uint64_t status = ~0ULL;
++	efi_status_t status = ~0UL;
+ 	uint8_t data = 1;
+ 	uint64_t datasize = 1;
+ 	uint64_t variablenamesize = MAX_DATA_LENGTH;
+@@ -2165,7 +2165,7 @@ static int uefirtvariable_test9(fwts_framework *fw)
+ 				fwts_passed(fw, "UEFI SetVariable runtime service "
+ 					"unsupported status test passed.");
+ 			else {
+-				if (status == ~0ULL)
++				if (status == ~0UL)
+ 					fwts_skipped(fw, "Unknown error occurred, skip test.");
+ 				else
+ 					fwts_failed(fw, LOG_LEVEL_HIGH, "UEFIRuntimeSetVariable",
+@@ -2200,7 +2200,7 @@ static int uefirtvariable_test9(fwts_framework *fw)
+ 				fwts_passed(fw, "UEFI GetVariable runtime service "
+ 					"unsupported status test passed.");
+ 			else {
+-				if (status == ~0ULL)
++				if (status == ~0UL)
+ 					fwts_skipped(fw, "Unknown error occurred, skip test.");
+ 				else
+ 					fwts_failed(fw, LOG_LEVEL_HIGH, "UEFIRuntimeGetVariable",
+@@ -2222,7 +2222,7 @@ static int uefirtvariable_test9(fwts_framework *fw)
+ 
+ 	/* delete the variable which was set */
+ 	setvariable.DataSize = 0;
+-	status = ~0ULL;
++	status = ~0UL;
+ 	(void)ioctl(fd, EFI_RUNTIME_SET_VARIABLE, &setvariable);
+ 
+ 	variablename = malloc(sizeof(uint16_t) * variablenamesize);
+@@ -2237,7 +2237,7 @@ static int uefirtvariable_test9(fwts_framework *fw)
+ 		getnextvariablename.VendorGuid = &guid;
+ 		getnextvariablename.status = &status;
+ 		variablename[0] = '\0';
+-		status = ~0ULL;
++		status = ~0UL;
+ 
+ 		ioret = ioctl(fd, EFI_RUNTIME_GET_NEXTVARIABLENAME, &getnextvariablename);
+ 		if (ioret == -1) {
+@@ -2245,7 +2245,7 @@ static int uefirtvariable_test9(fwts_framework *fw)
+ 				fwts_passed(fw, "UEFI GetNextVarName runtime service "
+ 					"unsupported status test passed.");
+ 			else {
+-				if (status == ~0ULL)
++				if (status == ~0UL)
+ 					fwts_skipped(fw, "Unknown error occurred, skip test.");
+ 				else
+ 					fwts_failed(fw, LOG_LEVEL_HIGH, "UEFIRuntimeGetNextVarName",
+@@ -2271,7 +2271,7 @@ static int uefirtvariable_test9(fwts_framework *fw)
+ 		queryvariableinfo.RemainingVariableStorageSize = &remvarstoragesize;
+ 		queryvariableinfo.MaximumVariableSize = &maxvariablesize;
+ 		queryvariableinfo.status = &status;
+-		status = ~0ULL;
++		status = ~0UL;
+ 
+ 		ioret = ioctl(fd, EFI_RUNTIME_QUERY_VARIABLEINFO, &queryvariableinfo);
+ 		if (ioret == -1) {
+@@ -2279,7 +2279,7 @@ static int uefirtvariable_test9(fwts_framework *fw)
+ 				fwts_passed(fw, "UEFI QueryVarInfo runtime service "
+ 					"unsupported status test passed.");
+ 			else {
+-				if (status == ~0ULL)
++				if (status == ~0UL)
+ 					fwts_skipped(fw, "Unknown error occurred, skip test.");
+ 				else
+ 					fwts_failed(fw, LOG_LEVEL_HIGH, "UEFIRuntimeQueryVarInfo",
+diff --git a/src/uefi/uefivarinfo/uefivarinfo.c b/src/uefi/uefivarinfo/uefivarinfo.c
+index 1386d17a..f31e2649 100644
+--- a/src/uefi/uefivarinfo/uefivarinfo.c
++++ b/src/uefi/uefivarinfo/uefivarinfo.c
+@@ -55,7 +55,7 @@ static int do_checkvariables(
+ 	uint64_t *usedvarssize,
+ 	const uint64_t maxvarsize)
+ {
+-	uint64_t status;
++	efi_status_t status;
+ 
+ 	struct efi_getnextvariablename getnextvariablename;
+ 	uint64_t variablenamesize = MAX_VARNAME_LENGTH;
+@@ -85,7 +85,7 @@ static int do_checkvariables(
+ 	variablename[0] = '\0';
+ 	while (true) {
+ 		long ioret;
+-		status = ~0ULL;
++		status = ~0UL;
+ 
+ 		variablenamesize = MAX_VARNAME_LENGTH;
+ 		ioret = ioctl(fd, EFI_RUNTIME_GET_NEXTVARIABLENAME, &getnextvariablename);
+@@ -114,7 +114,7 @@ static int do_checkvariables(
+ 		getvariable.VendorGuid = &vendorguid;
+ 		getvariable.DataSize = &getdatasize;
+ 		getvariable.Data = data;
+-		status = ~0ULL;
++		status = ~0UL;
+ 
+ 		ioret = ioctl(fd, EFI_RUNTIME_GET_VARIABLE, &getvariable);
+ 		if (ioret == -1) {
+@@ -139,7 +139,7 @@ static int do_checkvariables(
+ 				}
+ 
+ 				getvariable.Data = data;
+-				status = ~0ULL;
++				status = ~0UL;
+ 
+ 				ioret = ioctl(fd, EFI_RUNTIME_GET_VARIABLE, &getvariable);
+ 				if (ioret == -1) {
+@@ -161,7 +161,7 @@ static int do_checkvariables(
+ }
+ 
+ static int do_queryvariableinfo(
+-	uint64_t *status,
++	efi_status_t *status,
+ 	uint64_t *maxvarstoragesize,
+ 	uint64_t *remvarstoragesize,
+ 	uint64_t *maxvariablesize)
+@@ -175,7 +175,7 @@ static int do_queryvariableinfo(
+ 	queryvariableinfo.MaximumVariableStorageSize = maxvarstoragesize;
+ 	queryvariableinfo.RemainingVariableStorageSize = remvarstoragesize;
+ 	queryvariableinfo.MaximumVariableSize = maxvariablesize;
+-	*status = ~0ULL;
++	*status = ~0UL;
+ 	queryvariableinfo.status = status;
+ 
+ 	ioret = ioctl(fd, EFI_RUNTIME_QUERY_VARIABLEINFO, &queryvariableinfo);
+@@ -188,7 +188,7 @@ static int do_queryvariableinfo(
+ 
+ static int uefivarinfo_test1(fwts_framework *fw)
+ {
+-	uint64_t status;
++	efi_status_t status;
+ 	uint64_t remvarstoragesize;
+ 	uint64_t maxvariablesize;
+ 	uint64_t maxvarstoragesize;
+-- 
+2.35.1
+


### PR DESCRIPTION
We add a patch to simplify what we build in FWTS for 32b arm, and to enable UEFI support on 32b arm.
We supply a copy of libbsd's strlcpy() and strlcat() functions. We copy the libraries fwts needs at runtime from the compiler. This repairs the build for 32b arm and is sufficient to test for EBBR.

Signed-off-by: Vincent Stehlé <vincent.stehle@arm.com>