### PR TITLE
Added Assertion for BBSR secure boot tests, if they can't continue

### DIFF
--- a/bbsr/sct-tests/SecureBoot/BlackBoxTest/ImageLoadingBBTest.c
+++ b/bbsr/sct-tests/SecureBoot/BlackBoxTest/ImageLoadingBBTest.c
@@ -2,7 +2,7 @@
 
   Copyright 2006 - 2012 Unified EFI, Inc.<BR>
   Copyright (c) 2010 - 2018, Intel Corporation. All rights reserved.<BR>
-  Copyright 2021, Arm LTD.
+  Copyright 2021, 2023, Arm LTD.
 
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
@@ -150,6 +150,9 @@ ImageLoadingTest(
              );
 
   if (EFI_ERROR(Status)) {
+    EFI_TEST_GENERIC_FAILURE(
+          L"SecureBoot - ImageLoadingTest: Failed to get test support protocol library",
+      Status);
     return Status;
   }
 
@@ -160,6 +163,9 @@ ImageLoadingTest(
   //
   Status = GetSystemData (ProfileLib);
   if (EFI_ERROR(Status)) {
+    EFI_TEST_GENERIC_FAILURE(
+          L"SecureBoot - ImageLoadingTest: Failed to get system data",
+      Status);
     return Status;
   }
 
@@ -241,11 +247,9 @@ ImageLoadingVariableInit  (
 
   // if SecureBoot is not enabled, exit
   if (EFI_ERROR(Status) || Data[0] != 1) {
-    StandardLib->RecordMessage (
-                     StandardLib,
-                     EFI_VERBOSE_LEVEL_DEFAULT,
-                     L"Secure Boot ImageLoadingTest: SecureBoot not enabled\n"
-                     );
+    EFI_TEST_GENERIC_FAILURE(
+          L"SecureBoot - ImageLoadingTest: SecureBoot not enabled",
+      Status);
     return EFI_NOT_FOUND;
   }
 
@@ -265,6 +269,9 @@ ImageLoadingVariableInit  (
              );
 
   if (EFI_ERROR(Status)) {
+    EFI_TEST_GENERIC_FAILURE(
+      L"Secure Boot - ImageLoadingTest: OpenFileAndGetSize() failed for KEKSigList1.auth",
+      Status);
     return EFI_NOT_FOUND;
   }
 
@@ -272,6 +279,9 @@ ImageLoadingVariableInit  (
 
   if (Buffer == NULL) {
     KeyFHandle->Close (KeyFHandle);
+    EFI_TEST_GENERIC_FAILURE(
+      L"Secure Boot - ImageLoadingTest: Failed to allocate buffer for KEKSigList1.auth",
+      Status);
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -286,6 +296,9 @@ ImageLoadingVariableInit  (
   if (EFI_ERROR(Status)) {
     KeyFHandle->Close (KeyFHandle);
     gtBS->FreePool (Buffer);
+    EFI_TEST_GENERIC_FAILURE(
+      L"Secure Boot - ImageLoadingTest: Failed to read KEKSigList1.auth",
+      Status);
     return EFI_LOAD_ERROR;
   }
 
@@ -300,12 +313,9 @@ ImageLoadingVariableInit  (
   gtBS->FreePool (Buffer);
 
   if (EFI_ERROR(Status)) {
-    StandardLib->RecordMessage (
-                     StandardLib,
-                     EFI_VERBOSE_LEVEL_DEFAULT,
-                     L"Secure Boot ImageLoadingTest: unable to set KEK. Status=%r.\n",
-                     Status
-                     );
+    EFI_TEST_GENERIC_FAILURE(
+      L"Secure Boot - ImageLoadingTest: unable to set KEK",
+      Status);
     return EFI_NOT_FOUND;
   }
 
@@ -336,12 +346,9 @@ ImageLoadingVariableInit  (
              );
 
   if (EFI_ERROR(Status)) {
-    StandardLib->RecordMessage (
-                     StandardLib,
-                     EFI_VERBOSE_LEVEL_DEFAULT,
-                     L"Secure Boot ImageLoadingTest: couldn't load dbSigList2.auth. Status=%r.\n",
-                     Status
-                     );
+    EFI_TEST_GENERIC_FAILURE(
+      L"Secure Boot - ImageLoadingTest: OpenFileAndGetSize() failed for dbSigList2.auth",
+      Status);
     return EFI_NOT_FOUND;
   }
 
@@ -349,6 +356,9 @@ ImageLoadingVariableInit  (
 
   if (Buffer == NULL) {
     KeyFHandle->Close (KeyFHandle);
+    EFI_TEST_GENERIC_FAILURE(
+      L"Secure Boot - ImageLoadingTest: Failed to allocate buffer for dbSigList2.auth",
+      Status);
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -363,6 +373,9 @@ ImageLoadingVariableInit  (
   if (EFI_ERROR(Status)) {
     KeyFHandle->Close (KeyFHandle);
     gtBS->FreePool (Buffer);
+    EFI_TEST_GENERIC_FAILURE(
+      L"Secure Boot - ImageLoadingTest: Failed to read dbSigList2.auth",
+      Status);
     return EFI_LOAD_ERROR;
   }
 
@@ -377,12 +390,9 @@ ImageLoadingVariableInit  (
   gtBS->FreePool (Buffer);
 
   if (EFI_ERROR(Status)) {
-    StandardLib->RecordMessage (
-                     StandardLib,
-                     EFI_VERBOSE_LEVEL_DEFAULT,
-                     L"Secure Boot ImageLoadingTest: unable to set db. Status=%r.\n",
-                     Status
-                     );
+    EFI_TEST_GENERIC_FAILURE(
+      L"Secure Boot - ImageLoadingTest: unable to set db",
+      Status);
     return EFI_NOT_FOUND;
   }
 
@@ -413,12 +423,9 @@ ImageLoadingVariableInit  (
              );
 
   if (EFI_ERROR(Status)) {
-    StandardLib->RecordMessage (
-                     StandardLib,
-                     EFI_VERBOSE_LEVEL_DEFAULT,
-                     L"Secure Boot ImageLoadingTest: unable to load dbxRevokedList1.auth. Status=%r.\n",
-                     Status
-                     );
+    EFI_TEST_GENERIC_FAILURE(
+      L"Secure Boot - ImageLoadingTest: OpenFileAndGetSize() failed for dbxRevokedList1.auth",
+      Status);
     return EFI_NOT_FOUND;
   }
 
@@ -426,6 +433,9 @@ ImageLoadingVariableInit  (
 
   if (Buffer == NULL) {
     KeyFHandle->Close (KeyFHandle);
+    EFI_TEST_GENERIC_FAILURE(
+      L"Secure Boot - ImageLoadingTest: Failed to allocate buffer for dbxRevokedList1.auth",
+      Status);
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -440,6 +450,9 @@ ImageLoadingVariableInit  (
   if (EFI_ERROR(Status)) {
     KeyFHandle->Close (KeyFHandle);
     gtBS->FreePool (Buffer);
+    EFI_TEST_GENERIC_FAILURE(
+      L"Secure Boot - ImageLoadingTest: Failed to read dbxRevokedList1.auth",
+      Status);
     return EFI_LOAD_ERROR;
   }
 
@@ -454,12 +467,9 @@ ImageLoadingVariableInit  (
   gtBS->FreePool (Buffer);
 
   if (EFI_ERROR(Status)) {
-    StandardLib->RecordMessage (
-                     StandardLib,
-                     EFI_VERBOSE_LEVEL_DEFAULT,
-                     L"Secure Boot ImageLoadingTest: unable to set dbx. Status=%r.\n",
-                     Status
-                     );
+    EFI_TEST_GENERIC_FAILURE(
+      L"Secure Boot - ImageLoadingTest: unable to set dbx",
+      Status);
     return EFI_NOT_FOUND;
   }
 
@@ -1050,11 +1060,10 @@ ImageLoadingTestCheckpoint3 (
   Status = SctGetSystemConfigurationTable(&gEfiImageSecurityDatabaseGuid, &ptr);
 
   if (Status != EFI_SUCCESS) {
-    StandardLib->RecordMessage (
-                     StandardLib,
-                     EFI_VERBOSE_LEVEL_DEFAULT,
-                     L"Secure Boot ImageLoadingTest: EFI Image Execution Info Table not found.\n"
-                     );
+    EFI_TEST_GENERIC_FAILURE(
+      L"Secure Boot - ImageLoadingTest: EFI Image Execution Info Table not found",
+      Status);
+    
      return EFI_NOT_FOUND;
   }
 

--- a/bbsr/sct-tests/SecureBoot/BlackBoxTest/SecureBootBBTestMain.h
+++ b/bbsr/sct-tests/SecureBoot/BlackBoxTest/SecureBootBBTestMain.h
@@ -2,6 +2,7 @@
 
   Copyright 2006 - 2016 Unified EFI, Inc.<BR>
   Copyright (c) 2010 - 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright 2021, 2023, Arm LTD.
 
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
@@ -55,6 +56,19 @@ Abstract:
 
 #define IMAGE_LOADING_TEST_GUID \
   { 0xBA4A8DD9, 0x2D6A, 0x43A6, {0x96, 0xCF, 0x79, 0x47, 0x89, 0x2B, 0x73, 0x59 }}
+
+
+#define EFI_TEST_GENERIC_FAILURE(Title, Status)             \
+  StandardLib->RecordAssertion (                            \
+                 StandardLib,                               \
+                 EFI_TEST_ASSERTION_FAILED,                 \
+                 gTestGenericFailureGuid,                   \
+                 Title,                                     \
+                 L"%a:%d:Status - %r",                      \
+                 __FILE__,                                  \
+                 (UINTN)__LINE__,                           \
+                 Status                                     \
+                 );
 
 //
 // Prototypes

--- a/bbsr/sct-tests/SecureBoot/BlackBoxTest/VariableAttributesBBTest.c
+++ b/bbsr/sct-tests/SecureBoot/BlackBoxTest/VariableAttributesBBTest.c
@@ -2,7 +2,7 @@
 
   Copyright 2006 - 2012 Unified EFI, Inc.<BR>
   Copyright (c) 2010 - 2018, Intel Corporation. All rights reserved.<BR>
-  Copyright 2021, Arm LTD.
+  Copyright 2021, 2023 Arm LTD.
 
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
@@ -91,6 +91,9 @@ VariableAttributesTest(
              );
 
   if (EFI_ERROR(Status)) {
+    EFI_TEST_GENERIC_FAILURE(
+      L"SecureBoot - VariableAttributesBBTest: Failed to get test support protocol library",
+      Status);
     return Status;
   }
 
@@ -118,11 +121,8 @@ VariableAttributesTest(
 
   // if SecureBoot is not enabled, exit
   if (EFI_ERROR(Status) || Data[0] != 1) {
-    StandardLib->RecordMessage (
-                     StandardLib,
-                     EFI_VERBOSE_LEVEL_DEFAULT,
-                     L"VariableAttributesBBTest: SecureBoot not enabled\n"
-                     );
+    EFI_TEST_GENERIC_FAILURE(L"SecureBoot - VariableAttributesBBTest: SecureBoot not enabled",
+      Status);
     return EFI_NOT_FOUND;
   }
 
@@ -148,11 +148,7 @@ VariableAttributesTest(
 
   // if SetupMode != 0, exit
   if (EFI_ERROR(Status) || Data[0] != 0) {
-    StandardLib->RecordMessage (
-                     StandardLib,
-                     EFI_VERBOSE_LEVEL_DEFAULT,
-                     L"VariableAttributesBBTest: SetupMode != 0\n"
-                     );
+    EFI_TEST_GENERIC_FAILURE(L"SecureBoot - VariableAttributesBBTest: SetupMode != 0", Status);
     return EFI_NOT_FOUND;
   }
 

--- a/bbsr/sct-tests/SecureBoot/BlackBoxTest/VariableUpdatesBBTest.c
+++ b/bbsr/sct-tests/SecureBoot/BlackBoxTest/VariableUpdatesBBTest.c
@@ -2,7 +2,7 @@
 
   Copyright 2006 - 2012 Unified EFI, Inc.<BR>
   Copyright (c) 2010 - 2018, Intel Corporation. All rights reserved.<BR>
-  Copyright 2021, Arm LTD.
+  Copyright 2021, 2023, Arm LTD.
 
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
@@ -134,6 +134,9 @@ VariableUpdatesTest(
   // including known timestamps
   Status = SecureBootVariableCleanup (RT, StandardLib, LoggingLib, ProfileLib);
   if (EFI_ERROR(Status)) {
+    EFI_TEST_GENERIC_FAILURE(
+      L"SecureBoot - VariableUpdatesBBTest: SecureBootVariableCleanup() failed",
+      Status);
     return Status;
   }
 
@@ -220,11 +223,9 @@ VariableUpdatesTestCheckpoint1 (
 
   // if SecureBoot is not enabled, exit
   if (EFI_ERROR(Status) || Data[0] != 1) {
-    StandardLib->RecordMessage (
-                     StandardLib,
-                     EFI_VERBOSE_LEVEL_DEFAULT,
-                     L"VariableUpdatesBBTest: SecureBoot not enabled\n"
-                     );
+    EFI_TEST_GENERIC_FAILURE(
+      L"SecureBoot - VariableUpdatesBBTest: SecureBoot not enabled",
+      Status);
     return EFI_NOT_FOUND;
   }
 
@@ -240,6 +241,9 @@ VariableUpdatesTestCheckpoint1 (
              );
 
   if (EFI_ERROR(Status)) {
+    EFI_TEST_GENERIC_FAILURE(
+      L"SecureBoot - Verify unsigned KEK update: OpenFileAndGetSize() failed for TestImage1.bin",
+      Status);
     return EFI_NOT_FOUND;
   }
 
@@ -247,6 +251,9 @@ VariableUpdatesTestCheckpoint1 (
 
   if (Buffer == NULL) {
     KeyFHandle->Close (KeyFHandle);
+    EFI_TEST_GENERIC_FAILURE(
+      L"SecureBoot - Verify unsigned KEK update: Failed to allocate buffer for TestImage1.bin",
+      Status);
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -261,6 +268,9 @@ VariableUpdatesTestCheckpoint1 (
   if (EFI_ERROR(Status)) {
     KeyFHandle->Close (KeyFHandle);
     gtBS->FreePool (Buffer);
+    EFI_TEST_GENERIC_FAILURE(
+      L"SecureBoot - Verify unsigned KEK update: Failed to read TestImage1.bin",
+      Status);
     return EFI_LOAD_ERROR;
   }
 
@@ -307,6 +317,9 @@ VariableUpdatesTestCheckpoint1 (
              );
 
   if (EFI_ERROR(Status)) {
+    EFI_TEST_GENERIC_FAILURE(
+      L"SecureBoot - Verify signed KEK update: OpenFileAndGetSize() failed for KEKSigList1.auth",
+      Status);
     return EFI_NOT_FOUND;
   }
 
@@ -314,6 +327,9 @@ VariableUpdatesTestCheckpoint1 (
 
   if (Buffer == NULL) {
     KeyFHandle->Close (KeyFHandle);
+    EFI_TEST_GENERIC_FAILURE(
+      L"SecureBoot - Verify signed KEK update: Failed to allocate buffer for KEKSigList1.auth",
+      Status);
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -328,6 +344,9 @@ VariableUpdatesTestCheckpoint1 (
   if (EFI_ERROR(Status)) {
     KeyFHandle->Close (KeyFHandle);
     gtBS->FreePool (Buffer);
+    EFI_TEST_GENERIC_FAILURE(
+      L"SecureBoot - Verify signed KEK update: Failed to read KEKSigList1.auth",
+      Status);
     return EFI_LOAD_ERROR;
   }
 
@@ -444,6 +463,9 @@ VariableUpdatesTestCheckpoint2 (
              );
 
   if (EFI_ERROR(Status)) {
+    EFI_TEST_GENERIC_FAILURE(
+      L"SecureBoot - Verify unsigned db update: OpenFileAndGetSize() failed for TestImage1.bin",
+      Status);
     return EFI_NOT_FOUND;
   }
 
@@ -451,6 +473,9 @@ VariableUpdatesTestCheckpoint2 (
 
   if (Buffer == NULL) {
     KeyFHandle->Close (KeyFHandle);
+    EFI_TEST_GENERIC_FAILURE(
+      L"SecureBoot - Verify unsigned db update: Failed to allocate buffer for TestImage1.bin",
+      Status);
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -465,6 +490,9 @@ VariableUpdatesTestCheckpoint2 (
   if (EFI_ERROR(Status)) {
     KeyFHandle->Close (KeyFHandle);
     gtBS->FreePool (Buffer);
+    EFI_TEST_GENERIC_FAILURE(
+      L"SecureBoot - Verify unsigned db update: Failed to read TestImage1.bin",
+      Status);
     return EFI_LOAD_ERROR;
   }
 
@@ -509,6 +537,9 @@ VariableUpdatesTestCheckpoint2 (
              );
 
   if (EFI_ERROR(Status)) {
+    EFI_TEST_GENERIC_FAILURE(
+      L"SecureBoot - Verify signed db update: OpenFileAndGetSize() failed for dbSigList1.auth",
+      Status);
     return EFI_NOT_FOUND;
   }
 
@@ -516,6 +547,9 @@ VariableUpdatesTestCheckpoint2 (
 
   if (Buffer == NULL) {
     KeyFHandle->Close (KeyFHandle);
+    EFI_TEST_GENERIC_FAILURE(
+      L"SecureBoot - Verify signed db update: Failed to allocate buffer for dbSigList1.auth",
+      Status);
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -530,6 +564,9 @@ VariableUpdatesTestCheckpoint2 (
   if (EFI_ERROR(Status)) {
     KeyFHandle->Close (KeyFHandle);
     gtBS->FreePool (Buffer);
+    EFI_TEST_GENERIC_FAILURE(
+      L"SecureBoot - Verify signed db update: Failed to read dbSigList1.auth",
+      Status);
     return EFI_LOAD_ERROR;
   }
 
@@ -574,6 +611,9 @@ VariableUpdatesTestCheckpoint2 (
              );
 
   if (EFI_ERROR(Status)) {
+    EFI_TEST_GENERIC_FAILURE(
+      L"SecureBoot - Verify signed db update: OpenFileAndGetSize() failed for dbSigList2.auth",
+      Status);
     return EFI_NOT_FOUND;
   }
 
@@ -581,6 +621,9 @@ VariableUpdatesTestCheckpoint2 (
 
   if (Buffer == NULL) {
     KeyFHandle->Close (KeyFHandle);
+    EFI_TEST_GENERIC_FAILURE(
+      L"SecureBoot - Verify signed db update: Failed to allocate buffer for dbSigList2.auth",
+      Status);
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -595,6 +638,9 @@ VariableUpdatesTestCheckpoint2 (
   if (EFI_ERROR(Status)) {
     KeyFHandle->Close (KeyFHandle);
     gtBS->FreePool (Buffer);
+    EFI_TEST_GENERIC_FAILURE(
+      L"SecureBoot - Verify signed db update: Failed to read dbSigList2.auth",
+      Status);
     return EFI_LOAD_ERROR;
   }
 
@@ -639,6 +685,9 @@ VariableUpdatesTestCheckpoint2 (
              );
 
   if (EFI_ERROR(Status)) {
+    EFI_TEST_GENERIC_FAILURE(
+      L"SecureBoot - Verify signed db update signed by TESTKEK2: OpenFileAndGetSize() failed for dbSigList4.auth",
+      Status);
     return EFI_NOT_FOUND;
   }
 
@@ -646,6 +695,9 @@ VariableUpdatesTestCheckpoint2 (
 
   if (Buffer == NULL) {
     KeyFHandle->Close (KeyFHandle);
+    EFI_TEST_GENERIC_FAILURE(
+      L"SecureBoot - Verify signed db update signed by TESTKEK2: Failed to allocate buffer for dbSigList4.auth",
+      Status);
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -660,6 +712,9 @@ VariableUpdatesTestCheckpoint2 (
   if (EFI_ERROR(Status)) {
     KeyFHandle->Close (KeyFHandle);
     gtBS->FreePool (Buffer);
+    EFI_TEST_GENERIC_FAILURE(
+      L"SecureBoot - Verify signed db update signed by TESTKEK2: Failed to read dbSigList4.auth",
+      Status);
     return EFI_LOAD_ERROR;
   }
 
@@ -778,6 +833,9 @@ VariableUpdatesTestCheckpoint3 (
              );
 
   if (EFI_ERROR(Status)) {
+    EFI_TEST_GENERIC_FAILURE(
+      L"SecureBoot - Verify unsigned dbx update: OpenFileAndGetSize() failed for TestImage1.bin",
+      Status);
     return EFI_NOT_FOUND;
   }
 
@@ -785,6 +843,9 @@ VariableUpdatesTestCheckpoint3 (
 
   if (Buffer == NULL) {
     KeyFHandle->Close (KeyFHandle);
+    EFI_TEST_GENERIC_FAILURE(
+      L"SecureBoot - Verify unsigned dbx update: Failed to allocate buffer for TestImage1.bin",
+      Status);
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -799,6 +860,9 @@ VariableUpdatesTestCheckpoint3 (
   if (EFI_ERROR(Status)) {
     KeyFHandle->Close (KeyFHandle);
     gtBS->FreePool (Buffer);
+    EFI_TEST_GENERIC_FAILURE(
+      L"SecureBoot - Verify unsigned dbx update: Failed to read TestImage1.bin",
+      Status);
     return EFI_LOAD_ERROR;
   }
 
@@ -845,6 +909,9 @@ VariableUpdatesTestCheckpoint3 (
              );
 
   if (EFI_ERROR(Status)) {
+    EFI_TEST_GENERIC_FAILURE(
+      L"SecureBoot - Verify signed dbx update: OpenFileAndGetSize() failed for dbSigList3.auth",
+      Status);
     return EFI_NOT_FOUND;
   }
 
@@ -852,6 +919,9 @@ VariableUpdatesTestCheckpoint3 (
 
   if (Buffer == NULL) {
     KeyFHandle->Close (KeyFHandle);
+    EFI_TEST_GENERIC_FAILURE(
+      L"SecureBoot - Verify signed dbx update: Failed to allocate buffer for dbSigList3.auth",
+      Status);
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -866,6 +936,9 @@ VariableUpdatesTestCheckpoint3 (
   if (EFI_ERROR(Status)) {
     KeyFHandle->Close (KeyFHandle);
     gtBS->FreePool (Buffer);
+    EFI_TEST_GENERIC_FAILURE(
+      L"SecureBoot - Verify signed dbx update: Failed to read dbSigList3.auth",
+      Status);
     return EFI_LOAD_ERROR;
   }
 
@@ -983,6 +1056,9 @@ VariableUpdatesTestCheckpoint4 (
              );
 
   if (EFI_ERROR(Status)) {
+    EFI_TEST_GENERIC_FAILURE(
+      L"SecureBoot - Verify signed KEK append update: OpenFileAndGetSize() failed for KEKSigList3.auth",
+      Status);
     return EFI_NOT_FOUND;
   }
 
@@ -990,6 +1066,9 @@ VariableUpdatesTestCheckpoint4 (
 
   if (Buffer == NULL) {
     KeyFHandle->Close (KeyFHandle);
+    EFI_TEST_GENERIC_FAILURE(
+      L"SecureBoot - Verify signed KEK append update: Failed to allocate buffer for KEKSigList3.auth",
+      Status);
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -1004,6 +1083,9 @@ VariableUpdatesTestCheckpoint4 (
   if (EFI_ERROR(Status)) {
     KeyFHandle->Close (KeyFHandle);
     gtBS->FreePool (Buffer);
+    EFI_TEST_GENERIC_FAILURE(
+      L"SecureBoot - Verify signed KEK append update: Failed to read KEKSigList3.auth",
+      Status);
     return EFI_LOAD_ERROR;
   }
 
@@ -1050,6 +1132,9 @@ VariableUpdatesTestCheckpoint4 (
              );
 
   if (EFI_ERROR(Status)) {
+    EFI_TEST_GENERIC_FAILURE(
+      L"SecureBoot - Verify signed DB append update: OpenFileAndGetSize() failed for dbSigList5.auth",
+      Status);
     return EFI_NOT_FOUND;
   }
 
@@ -1057,6 +1142,9 @@ VariableUpdatesTestCheckpoint4 (
 
   if (Buffer == NULL) {
     KeyFHandle->Close (KeyFHandle);
+    EFI_TEST_GENERIC_FAILURE(
+      L"SecureBoot - Verify signed DB append update: Failed to allocate buffer for dbSigList5.auth",
+      Status);
     return EFI_OUT_OF_RESOURCES;
   }
 
@@ -1071,6 +1159,9 @@ VariableUpdatesTestCheckpoint4 (
   if (EFI_ERROR(Status)) {
     KeyFHandle->Close (KeyFHandle);
     gtBS->FreePool (Buffer);
+    EFI_TEST_GENERIC_FAILURE(
+      L"SecureBoot - Verify signed DB append update: Failed to read dbSigList5.auth",
+      Status);
     return EFI_LOAD_ERROR;
   }
 


### PR DESCRIPTION
 - In few secure boot SCT tests, test can exit in initial stages without recording a assertion and it wouldn't show up in Summary.ekl. Hence adding additional assertions whereever neccessary.