### PR TITLE
Added support for SCRT suite run

### DIFF
--- a/common/config/SCRT.conf
+++ b/common/config/SCRT.conf
@@ -1,0 +1,49 @@
+## @file
+#
+#  Copyright 2006 - 2010 Unified EFI, Inc.<BR>
+#  Copyright (c) 2010, Intel Corporation. All rights reserved.<BR>
+#
+#  This program and the accompanying materials
+#  are licensed and made available under the terms and conditions of the BSD License
+#  which accompanies this distribution.  The full text of the license may be found at 
+#  http://opensource.org/licenses/bsd-license.php
+# 
+#  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+# 
+##
+#/*++
+#
+# Module Name:
+#
+#   SCRT.conf
+#
+# Abstract:
+#
+#   This is UEFI 2.1 Runtime Test Utility SCRT Configuration file.
+#
+#
+#--*/
+[variable]
+SetVariable                 = TRUE
+GetVariable                 = TRUE
+GetNextVariableName         = TRUE
+QueryVariableInfo           = TRUE
+
+[time]
+GetTime                     = TRUE
+SetTime                     = TRUE
+SetWakeupTime               = TRUE
+GetWakeupTime               = TRUE
+
+[capsule]
+QueryCapsuleCapabilities    = TRUE
+UpdateCapsule               = TRUE
+
+[monotonicCount]
+GetNextHighMonotonicCount   = TRUE
+
+[reset]
+ColdReset                   = FALSE
+WarmReset                   = TRUE
+ShutDown                    = FALSE

--- a/common/config/ScrtStartup.nsh
+++ b/common/config/ScrtStartup.nsh
@@ -1,0 +1,94 @@
+# Copyright (c) 2023 ARM Limited and Contributors. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# Neither the name of ARM nor the names of its contributors may be used
+# to endorse or promote products derived from this software without specific
+# prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+echo -off
+
+for %i in 0 1 2 3 4 5 6 7 8 9 A B C D E F
+  if exist FS%i:\EFI\BOOT\bbr\SCT\SCRT then
+    #
+    # Found EFI SCRT harness
+    #
+    FS%i:
+    cd FS%i:\EFI\BOOT\bbr\SCT\SCRT
+    
+    #Check if SCRT run is already in progress
+    if  exist SCRT_run_progress.flag then
+        #This is a restart case after SCRT run.
+        #Save the logs and exit
+        echo "SCRT run is in progress. Saving the logs"
+        rm -q SCRT_run_progress.flag
+        SCRTAPP.efi -g SCRT.log
+        
+        #Save the logs in acs_results
+        for %j in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+            if exists FS%j:\acs_results\ then
+                mkdir FS%j:\acs_results\sct_results
+                mkdir FS%j:\acs_results\sct_results\SCRT
+                cp SCRT.log  FS%j:\acs_results\sct_results\SCRT\SCRT.log
+                cp SCRT.conf FS%j:\acs_results\sct_results\SCRT\SCRT.conf
+            endif
+        endfor
+
+        goto Done
+    endif
+    
+    echo SCRT run. Press any key to stop the EFI SCRT running
+    FS%i:\EFI\BOOT\bbr\SCT\stallforkey.efi 5
+    if %lasterror% == 0 then
+      goto Done
+    endif
+
+    echo "Note: The System will automatically reset as part of SCRT testing"
+
+    if  exist SCRT.log then
+        echo SCRT is already run. Press any key to run SCRT again. WARNING: Ensure you have backed up the existing logs.
+        FS%i:\EFI\BOOT\bbr\SCT\stallforkey.efi 5
+        if %lasterror% == 0 then
+            #Backup the existing logs
+            cp SCRT.log SCRT.log_previous_run
+            rm -q SCRT.log
+            goto StartSCRT
+        else
+            goto Done
+        endif
+    else
+        goto StartSCRT
+    endif
+
+
+:StartSCRT
+    cp SCRT.conf SCRT_run_progress.flag
+    Load SCRTDRIVER.efi
+    SCRTAPP -f SCRT.conf
+
+ endif
+endfor
+
+:Done
+
+


### PR DESCRIPTION
Added support to run SCRT in the ACS image automation run. The results shall be collected and stored automatically in the acs_results

SCRT is a supplement to SCT and is invoked under the EFI shell environment and used to validate UEFI Runtime Services implementations for compliance to the UEFI Specification. These tests are invoked after calling ExitBootServices().