### PR TITLE
Update source URL for FWTS

### DIFF
--- a/common/scripts/get_source.sh
+++ b/common/scripts/get_source.sh
@@ -63,7 +63,7 @@ get_cross_compiler()
 
 get_fwts_src()
 {
-    git clone --single-branch https://git.launchpad.net/fwts
+    git clone --single-branch git://kernel.ubuntu.com/hwe/fwts.git
     pushd $TOP_DIR/fwts
     git checkout V23.01.00
     git submodule update --init


### PR DESCRIPTION
FWTS source URL updated from https://git.launchpad.net/fwts to git://kernel.ubuntu.com/hwe/fwts.git