### PR TITLE
modify the data used for testing variable update with unsigned data

### DIFF
--- a/bbsr/sct-tests/SecureBoot/BlackBoxTest/Dependency/Images/GNUmakefile
+++ b/bbsr/sct-tests/SecureBoot/BlackBoxTest/Dependency/Images/GNUmakefile
@@ -50,7 +50,7 @@ TEST_PK1_CRT=$(BIN_DIR)/SecureBoot_TestPK1.crt
 TEST_PK1_KEY=$(BIN_DIR)/SecureBoot_TestPK1.key
 endif
 
-all: $(TEST_KEYS) TestKEK2 TestKEK3 KEKSigList1.auth KEKSigList3.auth TestImage1.bin TestImage2.bin TestImage3.bin TestImage4.bin TestImage5.bin TestImage6.bin TestImage7.bin TestImage8.bin TestImage9.bin TestImage10.bin NullKEK.auth NullDB.auth NullDBX.auth TestKEK1.auth TestDB1.auth TestDBX1.auth SignCert1 dbSigList1.auth SignCert2 SignCert3 SignCert4 RevokedCert1 RevokedCert2 RevokedCert3 RevokedCert4 dbSigList2.auth dbSigList3.auth dbSigList4.auth dbxRevokedList1.auth dbSigList5.auth
+all: $(TEST_KEYS) TestKEK2 TestKEK3 KEKSigList1.auth KEKSigList3.auth TestImage1.bin TestImage2.bin TestImage3.bin TestImage4.bin TestImage5.bin TestImage6.bin TestImage7.bin TestImage8.bin TestImage9.bin TestImage10.bin NullKEK.auth NullDB.auth NullDBX.auth TestKEK1.auth TestDB1.auth TestDBX1.auth SignCert1 dbSigList1.auth SignCert2 SignCert3 SignCert4 RevokedCert1 RevokedCert2 RevokedCert3 RevokedCert4 dbSigList2.auth dbSigList3.auth dbSigList4.auth dbxRevokedList1.auth dbSigList5.auth unsignedKeyUpdate
 
 TestImage1.bin:
 	cp $(SOURCE_DIR)/Application1.efi $(TARGET)_$(@)
@@ -210,6 +210,12 @@ dbxRevokedList1.auth: RevokedCert1 RevokedCert2 RevokedCert3 RevokedCert4
 dbSigList5.auth: Sign_Cert5
 	cert-to-efi-sig-list $(BIN_DIR)/SecureBoot_Sign_Cert5.crt $(BIN_DIR)/SecureBoot_TestDB10.esl
 	sign-efi-sig-list -a -c $(BIN_DIR)/SecureBoot_TestKEK3.crt -k $(BIN_DIR)/SecureBoot_TestKEK3.key -t "$(FUTURE_DATE4)" db $(BIN_DIR)/SecureBoot_TestDB10.esl $(BIN_DIR)/SecureBoot_DBSigList5.auth
+
+unsignedKeyUpdate:
+	openssl req -x509 -sha256 -newkey rsa:2048 -subj /CN=ACS_UNSIGNED_KEY/ -keyout $(TARGET)_$(@).key -out $(TARGET)_$(@).crt -nodes -days 4000
+	cert-to-efi-sig-list $(TARGET)_$(@).crt $(TARGET)_$(@).esl
+	# exporting a .auth file without signing it with PK or KEK for testing purposes
+	mv $(TARGET)_$(@).esl $(TARGET)_$(@).auth
 
 clean:
 	$(RM) $(BIN_DIR)/$(TARGET)_*.key

--- a/bbsr/sct-tests/SecureBoot/BlackBoxTest/VariableUpdatesBBTest.c
+++ b/bbsr/sct-tests/SecureBoot/BlackBoxTest/VariableUpdatesBBTest.c
@@ -230,10 +230,10 @@ VariableUpdatesTestCheckpoint1 (
   }
 
   //
-  // Test KEK update with unsigned data, expect security violation
+  // Test KEK update with unsigned signature list (4Kb in size), expect security violation
   //
 
-  FileName = L"TestImage1.bin";
+  FileName = L"unsignedKeyUpdate.auth";
   Status = OpenFileAndGetSize (
              FileName,
              &KeyFHandle,
@@ -242,7 +242,7 @@ VariableUpdatesTestCheckpoint1 (
 
   if (EFI_ERROR(Status)) {
     EFI_TEST_GENERIC_FAILURE(
-      L"SecureBoot - Verify unsigned KEK update: OpenFileAndGetSize() failed for TestImage1.bin",
+      L"SecureBoot - Verify unsigned KEK update: OpenFileAndGetSize() failed for unsignedKeyUpdate.auth",
       Status);
     return EFI_NOT_FOUND;
   }
@@ -252,7 +252,7 @@ VariableUpdatesTestCheckpoint1 (
   if (Buffer == NULL) {
     KeyFHandle->Close (KeyFHandle);
     EFI_TEST_GENERIC_FAILURE(
-      L"SecureBoot - Verify unsigned KEK update: Failed to allocate buffer for TestImage1.bin",
+      L"SecureBoot - Verify unsigned KEK update: Failed to allocate buffer for unsignedKeyUpdate.auth",
       Status);
     return EFI_OUT_OF_RESOURCES;
   }
@@ -269,7 +269,7 @@ VariableUpdatesTestCheckpoint1 (
     KeyFHandle->Close (KeyFHandle);
     gtBS->FreePool (Buffer);
     EFI_TEST_GENERIC_FAILURE(
-      L"SecureBoot - Verify unsigned KEK update: Failed to read TestImage1.bin",
+      L"SecureBoot - Verify unsigned KEK update: Failed to read unsignedKeyUpdate.auth",
       Status);
     return EFI_LOAD_ERROR;
   }
@@ -449,10 +449,10 @@ VariableUpdatesTestCheckpoint2 (
 
 
   //
-  // Test db update with unsigned data
+  // Test db update with unsigned signature list (4Kb in size), expect security violation
   //
 
-  FileName = L"TestImage1.bin";
+  FileName = L"unsignedKeyUpdate.auth";
   //
   // read the key data into memory.
   //
@@ -464,7 +464,7 @@ VariableUpdatesTestCheckpoint2 (
 
   if (EFI_ERROR(Status)) {
     EFI_TEST_GENERIC_FAILURE(
-      L"SecureBoot - Verify unsigned db update: OpenFileAndGetSize() failed for TestImage1.bin",
+      L"SecureBoot - Verify unsigned db update: OpenFileAndGetSize() failed for unsignedKeyUpdate.auth",
       Status);
     return EFI_NOT_FOUND;
   }
@@ -474,7 +474,7 @@ VariableUpdatesTestCheckpoint2 (
   if (Buffer == NULL) {
     KeyFHandle->Close (KeyFHandle);
     EFI_TEST_GENERIC_FAILURE(
-      L"SecureBoot - Verify unsigned db update: Failed to allocate buffer for TestImage1.bin",
+      L"SecureBoot - Verify unsigned db update: Failed to allocate buffer for unsignedKeyUpdate.auth",
       Status);
     return EFI_OUT_OF_RESOURCES;
   }
@@ -491,7 +491,7 @@ VariableUpdatesTestCheckpoint2 (
     KeyFHandle->Close (KeyFHandle);
     gtBS->FreePool (Buffer);
     EFI_TEST_GENERIC_FAILURE(
-      L"SecureBoot - Verify unsigned db update: Failed to read TestImage1.bin",
+      L"SecureBoot - Verify unsigned db update: Failed to read unsignedKeyUpdate.auth",
       Status);
     return EFI_LOAD_ERROR;
   }
@@ -818,10 +818,10 @@ VariableUpdatesTestCheckpoint3 (
 
 
   //
-  // Test dbx update with unsigned data
+  // Test dbx update with unsigned signature list (4Kb in size), expect security violation
   //
 
-  FileName = L"TestImage1.bin";
+  FileName = L"unsignedKeyUpdate.auth";
 
   //
   // read the key data into memory.
@@ -834,7 +834,7 @@ VariableUpdatesTestCheckpoint3 (
 
   if (EFI_ERROR(Status)) {
     EFI_TEST_GENERIC_FAILURE(
-      L"SecureBoot - Verify unsigned dbx update: OpenFileAndGetSize() failed for TestImage1.bin",
+      L"SecureBoot - Verify unsigned dbx update: OpenFileAndGetSize() failed for unsignedKeyUpdate.auth",
       Status);
     return EFI_NOT_FOUND;
   }
@@ -844,7 +844,7 @@ VariableUpdatesTestCheckpoint3 (
   if (Buffer == NULL) {
     KeyFHandle->Close (KeyFHandle);
     EFI_TEST_GENERIC_FAILURE(
-      L"SecureBoot - Verify unsigned dbx update: Failed to allocate buffer for TestImage1.bin",
+      L"SecureBoot - Verify unsigned dbx update: Failed to allocate buffer for unsignedKeyUpdate.auth",
       Status);
     return EFI_OUT_OF_RESOURCES;
   }
@@ -861,7 +861,7 @@ VariableUpdatesTestCheckpoint3 (
     KeyFHandle->Close (KeyFHandle);
     gtBS->FreePool (Buffer);
     EFI_TEST_GENERIC_FAILURE(
-      L"SecureBoot - Verify unsigned dbx update: Failed to read TestImage1.bin",
+      L"SecureBoot - Verify unsigned dbx update: Failed to read unsignedKeyUpdate.auth",
       Status);
     return EFI_LOAD_ERROR;
   }


### PR DESCRIPTION
 - ship a new siglist without signing to be used as unsigned data.