### PR TITLE
Update ir_bbr_fwts_tests.ini file

### DIFF
--- a/ebbr/config/ir_bbr_fwts_tests.ini
+++ b/ebbr/config/ir_bbr_fwts_tests.ini
@@ -5,13 +5,13 @@
 #TEST SUITE      TEST DESCRIPOTION
 #-------------------------------------------------------------------------------------
 #Unsafe tests:
-uefivarinfo     UEFI variable info query.
+#uefivarinfo     UEFI variable info query.                           This is test is now included in the --ebbr flag
 
 #UEFI tests:
 #csm             UEFI Compatibility Support Module test.
-esrt            Sanity check UEFI ESRT Table.
-uefibootpath    Sanity check for UEFI Boot Path Boot####.
+#esrt            Sanity check UEFI ESRT Table.                       This is test is now included in the --ebbr flag
+#uefibootpath    Sanity check for UEFI Boot Path Boot####.           This is test is now included in the --ebbr flag
 #uefirtmisc      UEFI miscellaneous runtime service interface tests. This is test is now included in the --ebbr flag
 #uefirttime      UEFI Runtime service time interface tests.          This is test is now included in the --ebbr flag
 #uefirtvariable  UEFI Runtime service variable interface tests.      This is test is now included in the --ebbr flag
-dt_base         Base device tree validity check
+#dt_base         Base device tree validity check                     This is test is now included in the --ebbr flag


### PR DESCRIPTION
Since https://bugs.launchpad.net/fwts/+bug/2003694, fwts has added efivarinfo, esrt, uefibootpath and dt_base tests to --ebbr option.