### PR TITLE
Fix SBBRRuntimeServices log info

### DIFF
--- a/common/sct-tests/sbbr-tests/SBBRRuntimeServices/BlackBoxTest/SBBRRuntimeServicesBBTestFunction.c
+++ b/common/sct-tests/sbbr-tests/SBBRRuntimeServices/BlackBoxTest/SBBRRuntimeServicesBBTestFunction.c
@@ -179,12 +179,7 @@ BBTestRuntimeServices (
                  L"  ConvertPointer            : %X\n"
                  L"  GetVariable               : %X\n"
                  L"  GetNextVariableName       : %X\n"
-                 L"  SetVariable               : %X\n"
-                 L"  GetNextHighMonotonicCount : %X\n"
-                 L"  ResetSystem               : %X\n"
-                 L"  QueryVariableInfo         : %X\n"
-                 L"  QueryCapsuleCapabilities  : %X\n"
-                 L"  UpdateCapsule             : %X\n",
+                 L"  SetVariable               : %X\n",
                  gtRT->GetTime,
                  gtRT->SetTime,
                  gtRT->GetWakeupTime,
@@ -193,7 +188,17 @@ BBTestRuntimeServices (
                  gtRT->ConvertPointer,
                  gtRT->GetVariable,
                  gtRT->GetNextVariableName,
-                 gtRT->SetVariable,
+                 gtRT->SetVariable
+                 );
+
+  StandardLib->RecordMessage (
+                 StandardLib,
+                 EFI_VERBOSE_LEVEL_DEFAULT,
+                 L"  GetNextHighMonotonicCount : %X\n"
+                 L"  ResetSystem               : %X\n"
+                 L"  QueryVariableInfo         : %X\n"
+                 L"  QueryCapsuleCapabilities  : %X\n"
+                 L"  UpdateCapsule             : %X\n",
                  gtRT->GetNextHighMonotonicCount,
                  gtRT->ResetSystem,
                  gtRT->QueryVariableInfo,


### PR DESCRIPTION
With this change, the full log information can be printed correctly (due to EFI_MAX_PRINT_BUFFER).
eg:
w/o patch
```
  Hdr.Signature             : 56524553544E5552
  Hdr.Revision              : 00020064
  Hdr.HeaderSize            : 00000088
  Hdr.CRC32                 : CA423A80
  Hdr.Reserved              : 00000000

  GetTime                   : EFF44AA4
  SetTime                   : EFF44930
  GetWakeupTime             : EFED7300
  SetWakeupTime             : EFED7300
  SetVirtualAddressMap      : EFF44C0C
  ConvertPointer            : EFED7328
  GetVariable               : EFF45648
  GetNextVariableName       : EFF4573C
  SetVariable               : EFF456C0
  GetNextHighMonotonicCount : EFED7300
  ResetSystem               : EFF44890
  QueryVariableInfo         : EFF45788
  QueryCapsuleCapabilities  : 

Returned Status Code: Success
```
with patch
```
  Hdr.Signature             : 56524553544E5552
  Hdr.Revision              : 00020064
  Hdr.HeaderSize            : 00000088
  Hdr.CRC32                 : CA423A80
  Hdr.Reserved              : 00000000

  GetTime                   : EFF44AA4
  SetTime                   : EFF44930
  GetWakeupTime             : EFED7300
  SetWakeupTime             : EFED7300
  SetVirtualAddressMap      : EFF44C0C
  ConvertPointer            : EFED7328
  GetVariable               : EFF45648
  GetNextVariableName       : EFF4573C
  SetVariable               : EFF456C0

  GetNextHighMonotonicCount : EFED7300
  ResetSystem               : EFF44890
  QueryVariableInfo         : EFF45788
  QueryCapsuleCapabilities  : EFF3C790
  UpdateCapsule             : EFF3C6A8


Returned Status Code: Success
```

Btw, I noticed that the `EfiCompliantBBTestRequired_uefi.c` has checked the Runtime Services, so shall we just remove this bbr case?