### PR TITLE
Update PlatformResetAttackMitigationPsciBBTestFunction.c

### DIFF
--- a/bbsr/sct-tests/PlatformResetAttackMitigationPsciTest/BlackBoxTest/PlatformResetAttackMitigationPsciBBTestFunction.c
+++ b/bbsr/sct-tests/PlatformResetAttackMitigationPsciTest/BlackBoxTest/PlatformResetAttackMitigationPsciBBTestFunction.c
@@ -144,7 +144,7 @@ PlatformResetAttackMitigationPsciTestSub1 (
   if (SmcArgs.Arg0 == 0)
       Result = EFI_TEST_ASSERTION_PASSED;
   else
-      Result = EFI_TEST_ASSERTION_FAILED;
+      Result = EFI_TEST_ASSERTION_WARNING;
 
   StandardLib->RecordAssertion (
                    StandardLib,


### PR DESCRIPTION
- BBSR doesn't mandate Platform Reset mitigation via PSCI methods, 
   hence changing test assertion to warning.