### PR TITLE
invoke SecureBootVariableCleanup in case of error

### DIFF
--- a/bbsr/sct-tests/SecureBoot/BlackBoxTest/VariableUpdatesBBTest.c
+++ b/bbsr/sct-tests/SecureBoot/BlackBoxTest/VariableUpdatesBBTest.c
@@ -142,19 +142,23 @@ VariableUpdatesTest(
 
   Status = VariableUpdatesTestCheckpoint1 (RT, StandardLib, LoggingLib, ProfileLib);
   if (EFI_ERROR(Status)) {
+    SecureBootVariableCleanup (RT, StandardLib, LoggingLib, ProfileLib);
     return Status;
   }
   Status = VariableUpdatesTestCheckpoint2 (RT, StandardLib, LoggingLib, ProfileLib);
   if (EFI_ERROR(Status)) {
+    SecureBootVariableCleanup (RT, StandardLib, LoggingLib, ProfileLib);
     return Status;
   }
   Status = VariableUpdatesTestCheckpoint3 (RT, StandardLib, LoggingLib, ProfileLib);
   if (EFI_ERROR(Status)) {
+    SecureBootVariableCleanup (RT, StandardLib, LoggingLib, ProfileLib);
     return Status;
   }
 
   VariableUpdatesTestCheckpoint4 (RT, StandardLib, LoggingLib, ProfileLib);
   if (EFI_ERROR(Status)) {
+    SecureBootVariableCleanup (RT, StandardLib, LoggingLib, ProfileLib);
     return Status;
   }
 


### PR DESCRIPTION
 - restoring Secure boot variables in case of efi errors.