### PR TITLE
changes to check authenticated variable store

### DIFF
--- a/bbsr/sct-tests/BBSRVariableSizeTest/BlackBoxTest/BBSRVariableSizeBBTestFunction.c
+++ b/bbsr/sct-tests/BBSRVariableSizeTest/BlackBoxTest/BBSRVariableSizeBBTestFunction.c
@@ -109,7 +109,7 @@ BBSRVariableSizeTestSub1 (
   )
 {
   EFI_STATUS            QueryVarStatus;
-  UINT32                ValidAttributes = EFI_VARIABLE_NON_VOLATILE|EFI_VARIABLE_BOOTSERVICE_ACCESS|EFI_VARIABLE_RUNTIME_ACCESS;
+  UINT32                ValidAttributes = EFI_VARIABLE_NON_VOLATILE|EFI_VARIABLE_BOOTSERVICE_ACCESS|EFI_VARIABLE_RUNTIME_ACCESS|EFI_VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACCESS;
   UINT64                MaximumVariableStorageSize;
   UINT64                RemainingVariableStorageSize;
   UINT64                MaximumVariableSize;


### PR DESCRIPTION
- added EFI_VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACCESS attribute for QueryVariableInfo call.

Fixes: #89