### PR TITLE
upgrade edk2 and edk2-test versions

### DIFF
--- a/common/config/bbr_source.cfg
+++ b/common/config/bbr_source.cfg
@@ -36,10 +36,10 @@ CROSS_COMPILER_URL=https://developer.arm.com/-/media/Files/downloads/gnu/${GCC_T
 GCC=tools/arm-gnu-toolchain-${GCC_TOOLS_VERSION}-x86_64-aarch64-none-linux-gnu/bin/aarch64-none-linux-gnu-
 
 # edk2-test source tag from  https://github.com/tianocore/edk2-test
-SCT_SRC_TAG=20c2cbf56eeec28273e102ba336795f1a8e87048
+SCT_SRC_TAG=ba6c13f4e4fa1bf92ed04f5cb969d6c8a76f8605
 
 # FWTS source tag from https://github.com/fwts/fwts
 FWTS_SRC_TAG=V23.01.00
 
 # EDK2 source tag from https://github.com/tianocore/edk2.git
-EDK2_SRC_VERSION=edk2-stable202411
+EDK2_SRC_VERSION=edk2-stable202505

--- a/common/scripts/build-sct.sh
+++ b/common/scripts/build-sct.sh
@@ -150,7 +150,7 @@ do_build()
         cp $BBR_DIR/sbbr/config/SBBR_extd_run.seq uefi-sct/SctPkg/BBR/
         cp $BBR_DIR/sbbr/config/EfiCompliant_SBBR.ini  uefi-sct/SctPkg/BBR/
         if [[ $BUILD_TYPE != S ]]; then
-        if git apply --check $TOP_DIR/patches/sctversion.patch; then
+            if git apply --check $TOP_DIR/patches/sctversion.patch; then
                 echo "Applying edk2-test BBR sctversion patch..."
                 git apply --ignore-whitespace --ignore-space-change $TOP_DIR/patches/sctversion.patch
             else
@@ -201,6 +201,16 @@ do_build()
     else
         echo  "Error while applying edk2-test BBR patch..."
         exit
+    fi
+
+    if [ $BUILD_PLAT = SBBR ]; then
+        if git apply --check $BBR_DIR/sbbr/patches/0001-Disable-BBTestGetImageInfoConformanceTestCheckpoint4.patch; then
+            echo "Applying edk2-test BBTestGetImageInfoConformanceTestCheckpoint4 patch..."
+            git apply --ignore-whitespace --ignore-space-change $BBR_DIR/sbbr/patches/0001-Disable-BBTestGetImageInfoConformanceTestCheckpoint4.patch
+        else
+            echo  "Error while applying edk2-test BBTestGetImageInfoConformanceTestCheckpoint4 patch..."
+            exit
+        fi
     fi
 
     # Apply BBSR patch for Systemready

--- a/common/sct-tests/sbbr-tests/BBR_SCT.dsc
+++ b/common/sct-tests/sbbr-tests/BBR_SCT.dsc
@@ -136,7 +136,7 @@
 
 [LibraryClasses.AARCH64]
   ArmLib|ArmPkg/Library/ArmLib/ArmBaseLib.inf
-  ArmSmcLib|ArmPkg/Library/ArmSmcLib/ArmSmcLib.inf
+  ArmSmcLib|MdePkg/Library/ArmSmcLib/ArmSmcLib.inf
 
 ###############################################################################
 #

--- a/sbbr/patches/0001-Disable-BBTestGetImageInfoConformanceTestCheckpoint4.patch
+++ b/sbbr/patches/0001-Disable-BBTestGetImageInfoConformanceTestCheckpoint4.patch
@@ -1,0 +1,28 @@
+From 96bfc5b992d011a7c2845e7eaf4413f50ee662b6 Mon Sep 17 00:00:00 2001
+From: Sathisha S <sathisha.shivaramappa@arm.com>
+Date: Tue, 23 Sep 2025 10:40:41 +0000
+Subject: [PATCH] Disable BBTestGetImageInfoConformanceTestCheckpoint4 test
+
+This test is disabled due to a clarification pending in
+UEFI Specification.
+The test causes synchronous exception in some environment
+---
+ .../BlackBoxTest/FirmwareManagementBBTestConformance.c          | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/FirmwareManagement/BlackBoxTest/FirmwareManagementBBTestConformance.c b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/FirmwareManagement/BlackBoxTest/FirmwareManagementBBTestConformance.c
+index 22e8dcf2..1b942df4 100644
+--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/FirmwareManagement/BlackBoxTest/FirmwareManagementBBTestConformance.c
++++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/FirmwareManagement/BlackBoxTest/FirmwareManagementBBTestConformance.c
+@@ -571,7 +571,7 @@ BBTestGetImageInfoConformanceTest (
+   BBTestGetImageInfoConformanceTestCheckpoint1 (StandardLib, FirmwareManagement);
+   BBTestGetImageInfoConformanceTestCheckpoint2 (StandardLib, FirmwareManagement);
+   BBTestGetImageInfoConformanceTestCheckpoint3 (StandardLib, FirmwareManagement);
+-  BBTestGetImageInfoConformanceTestCheckpoint4 (StandardLib, FirmwareManagement);
++  //BBTestGetImageInfoConformanceTestCheckpoint4 (StandardLib, FirmwareManagement);
+ 
+   return EFI_SUCCESS;
+ }
+-- 
+2.43.0
+


### PR DESCRIPTION
Upgraded edk2 to edk2-stable202505
Upgraded edk2-test to ba6c13f4e4fa1bf92ed04f5cb969d6c8a76f8605 commit

Adding patch contains disble of BBTestGetImageInfoConformanceTestCheckpoint4 test as this test causes synchronous exception in some environment.

In EDK2 202505, SmcLib moved from ArmPkg to MdePkg patch, same thing is updated in BBR_SCT.dsc file.