### PR TITLE
fix(test): GetNextMonotonicCount tests treat EFI_DEVICE_ERROR as warning

### DIFF
--- a/common/scripts/build-sct.sh
+++ b/common/scripts/build-sct.sh
@@ -224,6 +224,17 @@ do_build()
         fi
     fi
 
+    # Apply SCT patch (EBBR only) - applies in edk2-test repo (current dir is $TOP_DIR/$SCT_PATH)
+    if [[ "$BUILD_PLAT" == "EBBR" ]]; then
+            if git apply --check "$BBR_DIR/ebbr/patches/0001-sct-getnextmonotoniccount-handle-device-error.patch"; then
+                    echo "Applying EBBR SCT GetNextMonotonicCount patch..."
+                    git apply --ignore-whitespace --ignore-space-change $BBR_DIR/ebbr/patches/0001-sct-getnextmonotoniccount-handle-device-error.patch
+            else
+                    echo "Error while applying EBBR SCT GetNextMonotonicCount patch..."
+                    exit
+            fi
+    fi
+
     # Apply BBSR patch for Systemready
     if [[ $BUILD_TYPE != S ]]; then
         if git apply --check $BBR_DIR/bbsr/patches/0001-BBSR-Patch-for-UEFI-SCT-Build.patch; then

--- a/ebbr/patches/0001-sct-getnextmonotoniccount-handle-device-error.patch
+++ b/ebbr/patches/0001-sct-getnextmonotoniccount-handle-device-error.patch
@@ -1,0 +1,389 @@
+diff --git a/uefi-sct/SctPkg/TestCase/UEFI/EFI/BootServices/MiscBootServices/BlackBoxTest/MiscBootServicesBBTestFunction.c b/uefi-sct/SctPkg/TestCase/UEFI/EFI/BootServices/MiscBootServices/BlackBoxTest/MiscBootServicesBBTestFunction.c
+index 9524052a..39dae5bb 100644
+--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/BootServices/MiscBootServices/BlackBoxTest/MiscBootServicesBBTestFunction.c
++++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/BootServices/MiscBootServices/BlackBoxTest/MiscBootServicesBBTestFunction.c
+@@ -1483,6 +1483,10 @@ BBTestGetNextMonotonicCountInterfaceTest (
+   UINT8                                Buffer[1024];
+   RESET_DATA                           *ResetData;
+   UINTN                                Size;
++  EFI_STATUS                           Status1;
++  EFI_STATUS                           Status2;
++  BOOLEAN                              SeenSuccess;
++  BOOLEAN                              SeenDeviceError;
+ 
+   //
+   // Get the Standard Library Interface
+@@ -1540,23 +1544,35 @@ BBTestGetNextMonotonicCountInterfaceTest (
+     if (ResetData->TplIndex < TPL_ARRAY_SIZE) {
+       Index = ResetData->TplIndex;
+       Count = ResetData->Count;
++      SeenSuccess = FALSE;
++      SeenDeviceError = FALSE;
+       goto GetNextMonotonicCountStep2;
+     }
+   } else {
+     return EFI_LOAD_ERROR;
+   }
++  SeenSuccess = FALSE;
++  SeenDeviceError = FALSE;
+ 
+   for (Index = 0; Index < TPL_ARRAY_SIZE; Index++) {
+     //
+     // 4.5.2.1  GetNextMonotonicCount must succeed with valid parameters.
+     //
+     OldTpl = gtBS->RaiseTPL (TplArray[Index]);
+-    Status = gtBS->GetNextMonotonicCount (
++    Status1 = gtBS->GetNextMonotonicCount (
+                      &Count
+                      );
+     gtBS->RestoreTPL (OldTpl);
+-    if (Status == EFI_SUCCESS) {
++    if (Status1 == EFI_SUCCESS) {
++      SeenSuccess = TRUE;
++    } else if (Status1 == EFI_DEVICE_ERROR) {
++      SeenDeviceError = TRUE;
++    }
++
++    if (Status1 == EFI_SUCCESS) {
+       AssertionType = EFI_TEST_ASSERTION_PASSED;
++    } else if (Status1 == EFI_DEVICE_ERROR) {
++      AssertionType = EFI_TEST_ASSERTION_WARNING;
+     } else {
+       AssertionType = EFI_TEST_ASSERTION_FAILED;
+     }
+@@ -1572,16 +1588,24 @@ BBTestGetNextMonotonicCountInterfaceTest (
+                    L"%a:%d:Status - %r, TPL - %d",
+                    __FILE__,
+                    (UINTN)__LINE__,
+-                   Status,
++                   Status1,
+                    TplArray[Index]
+                    );
+     OldTpl = gtBS->RaiseTPL (TplArray[Index]);
+-    Status = gtBS->GetNextMonotonicCount (
++    Status2 = gtBS->GetNextMonotonicCount (
+                      &Count2
+                      );
+     gtBS->RestoreTPL (OldTpl);
+-    if (Status == EFI_SUCCESS) {
+-      AssertionType = EFI_TEST_ASSERTION_PASSED;
++    if (Status2 == EFI_SUCCESS) {
++      SeenSuccess = TRUE;
++    } else if (Status2 == EFI_DEVICE_ERROR) {
++      SeenDeviceError = TRUE;
++    }
++
++    if (Status2 == EFI_SUCCESS) {
++       AssertionType = EFI_TEST_ASSERTION_PASSED;
++    } else if (Status2 == EFI_DEVICE_ERROR) {
++      AssertionType = EFI_TEST_ASSERTION_WARNING;
+     } else {
+       AssertionType = EFI_TEST_ASSERTION_FAILED;
+     }
+@@ -1597,11 +1621,17 @@ BBTestGetNextMonotonicCountInterfaceTest (
+                    L"%a:%d:Status - %r, TPL - %d",
+                    __FILE__,
+                    (UINTN)__LINE__,
+-                   Status,
++                   Status2,
+                    TplArray[Index]
+                    );
+-    if (Count2 == Count + 1) {
+-      AssertionType = EFI_TEST_ASSERTION_PASSED;
++    if ((Status1 == EFI_SUCCESS) && (Status2 == EFI_SUCCESS)) {
++      if (Count2 == Count + 1) {
++        AssertionType = EFI_TEST_ASSERTION_PASSED;
++      } else {
++        AssertionType = EFI_TEST_ASSERTION_FAILED;
++      }
++    } else if ((Status1 == EFI_DEVICE_ERROR) && (Status2 == EFI_DEVICE_ERROR)) {
++      AssertionType = EFI_TEST_ASSERTION_WARNING;
+     } else {
+       AssertionType = EFI_TEST_ASSERTION_FAILED;
+     }
+@@ -1614,14 +1644,29 @@ BBTestGetNextMonotonicCountInterfaceTest (
+                     gMiscBootServicesBBTestFunctionAssertionGuid049: \
+                     gMiscBootServicesBBTestFunctionAssertionGuid050),
+                    L"BS.GetNextMonotonicCount - Count + 1 == Count2",
+-                   L"%a:%d:Count - %lx, Count2 - %lx, TPL - %d",
++                   L"%a:%d:Count - %lx, Count2 - %lx, Status1 - %r, Status2 - %r, TPL - %d",
+                    __FILE__,
+                    (UINTN)__LINE__,
+                    Count,
+                    Count2,
+-                   TplArray[Index]
++                   Status1,
++                   Status2,
++                   TplArray[Index]
+                    );
+ 
++    if (SeenSuccess && SeenDeviceError) {
++      StandardLib->RecordAssertion (
++                 StandardLib,
++                 EFI_TEST_ASSERTION_FAILED,
++                 gTestGenericFailureGuid,
++                 L"BS.GetNextMonotonicCount - inconsistent behavior (mixed EFI_SUCCESS and EFI_DEVICE_ERROR)",
++                 L"%a:%d",
++                 __FILE__,
++                 (UINTN)__LINE__
++                 );
++      continue;
++    }
++
+     //
+     // 4.5.2.2  GetNextMonotonicCount after reset.
+     //
+@@ -1630,11 +1675,30 @@ BBTestGetNextMonotonicCountInterfaceTest (
+                      &Count
+                      );
+     gtBS->RestoreTPL (OldTpl);
++    if (Status == EFI_SUCCESS) {
++      SeenSuccess = TRUE;
++    } else if (Status == EFI_DEVICE_ERROR) {
++      SeenDeviceError = TRUE;
++    }
+     if (Status == EFI_SUCCESS) {
+       AssertionType = EFI_TEST_ASSERTION_PASSED;
++    } else if (Status == EFI_DEVICE_ERROR) {
++      AssertionType = EFI_TEST_ASSERTION_WARNING;
+     } else {
+       AssertionType = EFI_TEST_ASSERTION_FAILED;
+     }
++    if (SeenSuccess && SeenDeviceError) {
++      StandardLib->RecordAssertion (
++                   StandardLib,
++                   EFI_TEST_ASSERTION_FAILED,
++                   gTestGenericFailureGuid,
++                   L"BS.GetNextMonotonicCount - inconsistent behavior (mixed EFI_SUCCESS and EFI_DEVICE_ERROR)",
++                   L"%a:%d",
++                   __FILE__,
++                   (UINTN)__LINE__
++                   );
++      continue;
++    }
+     StandardLib->RecordAssertion (
+                    StandardLib,
+                    AssertionType,
+@@ -1650,6 +1714,12 @@ BBTestGetNextMonotonicCountInterfaceTest (
+                    Status,
+                    TplArray[Index]
+                    );
++    if (Status == EFI_DEVICE_ERROR) {
++      continue;
++    }
++    if (Status != EFI_SUCCESS) {
++      continue;
++    }
+     //
+     //  save the high 32 bit and reset system
+     //
+@@ -1691,11 +1761,30 @@ GetNextMonotonicCountStep2:
+                      &Count2
+                      );
+     gtBS->RestoreTPL (OldTpl);
++    if (Status == EFI_SUCCESS) {
++      SeenSuccess = TRUE;
++    } else if (Status == EFI_DEVICE_ERROR) {
++      SeenDeviceError = TRUE;
++    }
+     if (Status == EFI_SUCCESS) {
+       AssertionType = EFI_TEST_ASSERTION_PASSED;
++    } else if (Status == EFI_DEVICE_ERROR) {
++      AssertionType = EFI_TEST_ASSERTION_WARNING;
+     } else {
+       AssertionType = EFI_TEST_ASSERTION_FAILED;
+     }
++    if (SeenSuccess && SeenDeviceError) {
++      StandardLib->RecordAssertion (
++                   StandardLib,
++                   EFI_TEST_ASSERTION_FAILED,
++                   gTestGenericFailureGuid,
++                   L"BS.GetNextMonotonicCount - inconsistent behavior (mixed EFI_SUCCESS and EFI_DEVICE_ERROR)",
++                   L"%a:%d",
++                   __FILE__,
++                   (UINTN)__LINE__
++                   );
++      continue;
++    }
+     StandardLib->RecordAssertion (
+                    StandardLib,
+                    AssertionType,
+@@ -1711,6 +1800,9 @@ GetNextMonotonicCountStep2:
+                    Status,
+                    TplArray[Index]
+                    );
++    if (Status != EFI_SUCCESS) {
++      continue;
++    }
+ 
+     //The new count of upper 32 bits must be atleast 1 more than the old count.
+     //Pass case: new count is equal to old count + 1
+diff --git a/uefi-sct/SctPkg/TestCase/UEFI/EFI/BootServices/MiscBootServices/BlackBoxTest/MiscBootServicesBBTestStress.c b/uefi-sct/SctPkg/TestCase/UEFI/EFI/BootServices/MiscBootServices/BlackBoxTest/MiscBootServicesBBTestStress.c
+index e9d9d471..2b6e1a1f 100644
+--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/BootServices/MiscBootServices/BlackBoxTest/MiscBootServicesBBTestStress.c
++++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/BootServices/MiscBootServices/BlackBoxTest/MiscBootServicesBBTestStress.c
+@@ -513,6 +513,11 @@ BBTestGetNextMonotonicCountStressTest (
+   UINT8                                ResetBuffer[1024];
+   RESET_DATA                           *ResetData;
+   UINTN                                Size;
++  EFI_STATUS                           Status1;
++  EFI_STATUS                           Status2;
++  BOOLEAN                              SeenSuccess;
++  BOOLEAN                              SeenDeviceError;
++
+ 
+   //
+   // Get the Standard Library Interface
+@@ -570,23 +575,31 @@ BBTestGetNextMonotonicCountStressTest (
+     if (ResetData->TplIndex < TPL_ARRAY_SIZE) {
+       Index = ResetData->TplIndex;
+       OldCount = ResetData->Count;
++      SeenSuccess = FALSE;
++      SeenDeviceError = FALSE;
+       goto StressTestStep2;
+     }
+   } else {
+     return EFI_LOAD_ERROR;
+   }
++  SeenSuccess = FALSE;
++  SeenDeviceError = FALSE;
+ 
+   for (Index = 0; Index < TPL_ARRAY_SIZE; Index++) {
+     //
+     // 5.5.2.1  Stress test for GetNextMonotonicCount.
+     //
+     OldTpl = gtBS->RaiseTPL (TplArray[Index]);
+-    Status = gtBS->GetNextMonotonicCount (
++    Status1 = gtBS->GetNextMonotonicCount (
+                      &OldCount
+                      );
+     gtBS->RestoreTPL (OldTpl);
+-    if (Status == EFI_SUCCESS) {
++    if (Status1 == EFI_SUCCESS) {
++      SeenSuccess = TRUE;
+       AssertionType = EFI_TEST_ASSERTION_PASSED;
++    } else if (Status1 == EFI_DEVICE_ERROR) {
++      SeenDeviceError = TRUE;
++      AssertionType = EFI_TEST_ASSERTION_WARNING;
+     } else {
+       AssertionType = EFI_TEST_ASSERTION_FAILED;
+     }
+@@ -598,17 +611,24 @@ BBTestGetNextMonotonicCountStressTest (
+                    L"%a:%d:Status - %r, TPL - %d",
+                    __FILE__,
+                    (UINTN)__LINE__,
+-                   Status,
++                   Status1,
+                    TplArray[Index]
+                    );
++    if (Status1 == EFI_DEVICE_ERROR) {
++      continue;
++    }
+     for (RepeatTimes = 0; RepeatTimes < MAX_REPEAT_TIMES; RepeatTimes++) {
+       OldTpl = gtBS->RaiseTPL (TplArray[Index]);
+-      Status = gtBS->GetNextMonotonicCount (
++      Status2 = gtBS->GetNextMonotonicCount (
+                        &Count
+                        );
+       gtBS->RestoreTPL (OldTpl);
+-      if (Status == EFI_SUCCESS) {
++      if (Status2 == EFI_SUCCESS) {
++        SeenSuccess = TRUE;
+         AssertionType = EFI_TEST_ASSERTION_PASSED;
++      } else if (Status2 == EFI_DEVICE_ERROR) {
++        SeenDeviceError = TRUE;
++        AssertionType = EFI_TEST_ASSERTION_WARNING;
+       } else {
+         AssertionType = EFI_TEST_ASSERTION_FAILED;
+       }
+@@ -620,10 +640,14 @@ BBTestGetNextMonotonicCountStressTest (
+                      L"%a:%d:Status - %r, TPL - %d, Times - %d",
+                      __FILE__,
+                      (UINTN)__LINE__,
+-                     Status,
++                     Status2,
+                      TplArray[Index],
+                      RepeatTimes
+                      );
++      if (Status2 != EFI_SUCCESS) {
++        // Can't validate monotonic progression if the call failed.
++        break;
++      }
+       if (Count == OldCount + 1) {
+         AssertionType = EFI_TEST_ASSERTION_PASSED;
+       } else {
+@@ -634,10 +658,9 @@ BBTestGetNextMonotonicCountStressTest (
+                      AssertionType,
+                      gMiscBootServicesCombinationTestAssertionGuid009,
+                      L"BS.GetNextMonotonicCount - Count == OldCount + 1",
+-                     L"%a:%d:Status - %r, TPL - %d, Count - %lx, OldCount - %lx, Times - %d",
++                     L"%a:%d:TPL - %d, Count - %lx, OldCount - %lx, Times - %d",
+                      __FILE__,
+                      (UINTN)__LINE__,
+-                     Status,
+                      TplArray[Index],
+                      Count,
+                      OldCount,
+@@ -645,6 +668,19 @@ BBTestGetNextMonotonicCountStressTest (
+                      );
+       OldCount = Count;
+     }
++    // If we ever observe both EFI_SUCCESS and EFI_DEVICE_ERROR, behavior is inconsistent.
++    if (SeenSuccess && SeenDeviceError) {
++      StandardLib->RecordAssertion (
++                   StandardLib,
++                   EFI_TEST_ASSERTION_FAILED,
++                   gTestGenericFailureGuid,
++                   L"BS.GetNextMonotonicCount - inconsistent behavior (mixed EFI_SUCCESS and EFI_DEVICE_ERROR)",
++                   L"%a:%d",
++                   __FILE__,
++                   (UINTN)__LINE__
++                   );
++      continue;
++    }
+ 
+     //
+     //  save the high 32 bit and reset system
+@@ -683,12 +719,16 @@ BBTestGetNextMonotonicCountStressTest (
+ StressTestStep2:
+ 
+     OldTpl = gtBS->RaiseTPL (TplArray[Index]);
+-    Status = gtBS->GetNextMonotonicCount (
++    Status2 = gtBS->GetNextMonotonicCount (
+                      &Count
+                      );
+     gtBS->RestoreTPL (OldTpl);
+-    if (Status == EFI_SUCCESS) {
++    if (Status2 == EFI_SUCCESS) {
++      SeenSuccess = TRUE;
+       AssertionType = EFI_TEST_ASSERTION_PASSED;
++    } else if (Status2 == EFI_DEVICE_ERROR) {
++      SeenDeviceError = TRUE;
++      AssertionType = EFI_TEST_ASSERTION_WARNING;
+     } else {
+       AssertionType = EFI_TEST_ASSERTION_FAILED;
+     }
+@@ -700,9 +740,15 @@ StressTestStep2:
+                    L"%a:%d:Status - %r, TPL - %d",
+                    __FILE__,
+                    (UINTN)__LINE__,
+-                   Status,
++                   Status2,
+                    TplArray[Index]
+                    );
++    if (Status2 == EFI_DEVICE_ERROR) {
++      continue;
++    }
++    if (Status2 != EFI_SUCCESS) {
++      continue;
++    }
+ 
+     if (SctRShiftU64 (Count, 32) == SctRShiftU64 (OldCount, 32) + 1) {
+       AssertionType = EFI_TEST_ASSERTION_PASSED;
+@@ -725,4 +771,4 @@ StressTestStep2:
+   }
+ 
+   return EFI_SUCCESS;
+-}
+\ No newline at end of file
++}


### PR DESCRIPTION
- Failure in case of EFI_DEVICE_ERROR return is downgraded to Warning
- Status will be Failed if any other error status is observed or on inconsistent behaviour


Change-Id: I5e49665fb7fe5f9427dcfb05ab5ada9162930526