### PR TITLE
build-sct.sh: correct SCT signing paths

### DIFF
--- a/common/scripts/build-sct.sh
+++ b/common/scripts/build-sct.sh
@@ -48,8 +48,7 @@ TEST_DB1_KEY=$KEYS_DIR/TestDB1.key
 TEST_DB1_CRT=$KEYS_DIR/TestDB1.crt
 SCT_FRAMEWORK_PREFIX="$TOP_DIR/$SCT_PATH/uefi-sct/Build/bbrSct"
 SCT_FRAMEWORK_ROOT="$SCT_FRAMEWORK_PREFIX/${UEFI_BUILD_MODE}_${UEFI_TOOLCHAIN}"
-SCT_FRAMEWORK="$SCT_FRAMEWORK_ROOT/SctPackage${TARGET_ARCH}/\
-    ${TARGET_ARCH}"
+SCT_FRAMEWORK="$SCT_FRAMEWORK_ROOT/SctPackage${TARGET_ARCH}/${TARGET_ARCH}"
 
 BUILD_PLAT=$1
 BUILD_TYPE=$2
@@ -383,8 +382,9 @@ SecureBootSign() {
     echo "KEYS_DIR = $KEYS_DIR"
 
     for f in "$1"/*.efi; do
-        echo "sbsign --key $TEST_DB1_KEY --cert $TEST_DB1_CRT $f --output $f"
-        sbsign --key $TEST_DB1_KEY --cert $TEST_DB1_CRT $f --output $f
+        echo "sbsign --key $TEST_DB1_KEY --cert $TEST_DB1_CRT \"$f\" --output \"$f\""
+        sbsign --key "$TEST_DB1_KEY" --cert "$TEST_DB1_CRT" "$f" \
+            --output "$f"
     done
 }
 
@@ -393,8 +393,9 @@ SecureBootSignDependency() {
     echo "KEYS_DIR = $KEYS_DIR"
 
     for f in "$SCT_FRAMEWORK/Dependency/$1BBTest"/*.efi; do
-        echo "sbsign --key $TEST_DB1_KEY --cert $TEST_DB1_CRT $f --output $f"
-        sbsign --key $TEST_DB1_KEY --cert $TEST_DB1_CRT $f --output $f
+        echo "sbsign --key $TEST_DB1_KEY --cert $TEST_DB1_CRT \"$f\" --output \"$f\""
+        sbsign --key "$TEST_DB1_KEY" --cert "$TEST_DB1_CRT" "$f" \
+            --output "$f"
     done
 }
 


### PR DESCRIPTION
Build the SCT framework path without embedded whitespace so sbsign targets the correct AARCH64 EFI directory. Also quote sbsign input and output paths to avoid path parsing issues during signing.


Change-Id: I23aae35785c62dd1acb51ac4645cced2a4dae800