### PR TITLE
SBBR: improve PCIe Option ROM compliance reporting

### DIFF
--- a/docs/PcieOptionRomArchAudit.md
+++ b/docs/PcieOptionRomArchAudit.md
@@ -69,6 +69,12 @@ Report mode prints every scanned PCIe device, even if it has no option ROM. Devi
 - `EFI_COMPROMISED_DATA`: an option ROM is malformed or cannot be parsed.
 - `EFI_DEVICE_ERROR`: a PCI device could not be inspected.
 
+The final summary reports `BBR (UEFI 6.3.3.1 UEFI Drivers) Result Summary` with one of these outcomes:
+
+- `FAIL`: one or more PCIe option ROM devices contain UEFI driver images but no AARCH64 UEFI driver. Each affected device is listed with the reason `UEFI driver image(s) present but no AARCH64 UEFI driver found`.
+- `PASS`: PCIe devices with option ROMs were found, and their UEFI driver images include AARCH64 format.
+- `SKIP`: no PCIe devices with an option ROM were found. The summary prints `Reason: No PCIe devices with Option ROM were found.`
+
 - `HIT`: the option ROM contains one or more UEFI driver images, and does not contain an AARCH64 UEFI driver image.
 - `legacy-x86`: a PC-AT compatible legacy option ROM image was found.
 - `ia32-uefi`, `x64-uefi`, `arm64-uefi`, `ebc-uefi`, `other-uefi`: presence of UEFI **driver** images for those machine types within the option ROM.

--- a/sbbr/uefi_app/PcieOptionRomArchAudit.c
+++ b/sbbr/uefi_app/PcieOptionRomArchAudit.c
@@ -161,6 +161,8 @@ AuditLog (
 {
   VA_LIST  Marker;
   CHAR16   Buffer[1024];
+  CHAR8    AsciiBuffer[1024];
+  UINTN    Index;
   UINTN    Size;
 
   if (mLogFile == NULL) {
@@ -171,8 +173,16 @@ AuditLog (
   UnicodeVSPrint (Buffer, sizeof (Buffer), Format, Marker);
   VA_END (Marker);
 
-  Size = StrSize (Buffer);
-  ShellWriteFile (mLogFile, &Size, Buffer);
+  //
+  // Write byte-oriented text so UEFI Shell's "cat" does not render the
+  // UTF-16 NUL byte after every character as a dot.
+  //
+  Size = StrLen (Buffer);
+  for (Index = 0; Index < Size; Index++) {
+    AsciiBuffer[Index] = (Buffer[Index] <= 0x7f) ? (CHAR8)Buffer[Index] : '?';
+  }
+
+  ShellWriteFile (mLogFile, &Size, AsciiBuffer);
 }
 
 #define LOG(...)  AuditLog (__VA_ARGS__)
@@ -1624,27 +1634,39 @@ PrintFinalSummary (
   LOG (L"Inspection errors          : %u\n", (UINT32)Stats->InspectionErrors);
   LOG (L"Non-compliant devices      : %u\n", (UINT32)Stats->Hits);
 
-  if (NonCompliantDeviceCount == 0) {
-    return;
-  }
-
-  LOG (L"\nNon-compliant device summary:\n");
-  LOG (L"----------------------------------------\n");
-  for (Index = 0; Index < NonCompliantDeviceCount; Index++) {
+  LOG (L"\n");
+  if (Stats->DevicesWithRom == 0) {
     LOG (
-      L"  BDF=%04x:%02x:%02x.%x %s [%04x:%04x] DeviceName=%s\n",
-      (UINT32)NonCompliantDevices[Index].Segment,
-      (UINT32)NonCompliantDevices[Index].Bus,
-      (UINT32)NonCompliantDevices[Index].Device,
-      (UINT32)NonCompliantDevices[Index].Function,
-      VendorIdToStr (NonCompliantDevices[Index].VendorId),
-      (UINT32)NonCompliantDevices[Index].VendorId,
-      (UINT32)NonCompliantDevices[Index].DeviceId,
-      NonCompliantDevices[Index].DeviceName
+      L"BBR (UEFI 6.3.3.1 UEFI Drivers) Result Summary: SKIP\n"
       );
     LOG (
-      L"    Reason: UEFI driver image(s) (IA32/X64/EBC) present but no "
-      L"AARCH64 UEFI driver found\n"
+      L"Reason: No PCIe devices with Option ROM were found.\n"
+      );
+  } else if (Stats->Hits != 0) {
+    LOG (
+      L"BBR (UEFI 6.3.3.1 UEFI Drivers) Result Summary: FAIL\n"
+      );
+    LOG (L"\n----------------------------------------\n");
+    for (Index = 0; Index < NonCompliantDeviceCount; Index++) {
+      LOG (
+        L"  BDF=%04x:%02x:%02x.%x %s [%04x:%04x] DeviceName=%s\n",
+        (UINT32)NonCompliantDevices[Index].Segment,
+        (UINT32)NonCompliantDevices[Index].Bus,
+        (UINT32)NonCompliantDevices[Index].Device,
+        (UINT32)NonCompliantDevices[Index].Function,
+        VendorIdToStr (NonCompliantDevices[Index].VendorId),
+        (UINT32)NonCompliantDevices[Index].VendorId,
+        (UINT32)NonCompliantDevices[Index].DeviceId,
+        NonCompliantDevices[Index].DeviceName
+        );
+      LOG (
+        L"    Reason: UEFI driver image(s) present but no "
+        L"AARCH64 UEFI driver found\n"
+        );
+    }
+  } else {
+    LOG (
+      L"BBR (UEFI 6.3.3.1 UEFI Drivers) Result Summary: PASS\n"
       );
   }
 }
@@ -1884,7 +1906,7 @@ UefiMain (
     }
 
     Hit = (BOOLEAN)(
-            (Audit.HasIa32Uefi || Audit.HasX64Uefi || Audit.HasEbcUefi) &&
+            (Audit.DriverImageCount != 0) &&
             !Audit.HasArm64Uefi
             );
     AccumulateRunStats (&Stats, &Audit, Hit);


### PR DESCRIPTION
Add BBR rule PASS/FAIL/SKIP result reporting and list non-compliant PCIe devices on failure. Also write audit logs as byte-oriented text for correct display in the UEFI Shell.


Change-Id: Ie237cf7980db25834838f0559368e6d8c8a2fa17